### PR TITLE
Fix Russian translation of Clear

### DIFF
--- a/Project/src/main/resources/TranslationResources.properties
+++ b/Project/src/main/resources/TranslationResources.properties
@@ -17,13 +17,13 @@ zh.text.today=\u8fd9\u5929
 # Translations for Clear:
 # These are translations for the word "Clear", that are used with the date picker Clear Button.
 # Not all languages have a distinct translation for the word clear.
-# The definition of clear as a verb is: "To remove something that is not needed from a place." 
+# The definition of clear as a verb is: "To remove something that is not needed from a place."
 # Possible alternative button words are "None", "Empty", or "Delete".
 en.text.clear=Clear
 de.text.clear=L\u00f6schen
 fr.text.clear=Nettoyer
 pt.text.clear=Apagar
-ru.text.clear=O\u0447\u0438\u0449\u0430\u0442\u044c
+ru.text.clear=\u041e\u0447\u0438\u0441\u0442\u0438\u0442\u044c
 it.text.clear=Sgombrare
 nl.text.clear=Ontruimen
 es.text.clear=Limpiar


### PR DESCRIPTION
The Russian translation of Clear was "Очищать" - that is an infinitive form meaning "To clear".
This PR updates translation to "Очистить" which is call to action form and means "Clear"