### PR TITLE
Feature request #25: Color settings for TimePicker

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -3,7 +3,7 @@ package com.github.lgooddatepicker.components;
 import java.time.*;
 import com.privatejgoodies.forms.layout.FormLayout;
 import com.privatejgoodies.forms.factories.CC;
-import com.github.lgooddatepicker.components.DatePickerSettings.Area;
+import com.github.lgooddatepicker.components.DatePickerSettings.DateArea;
 import com.github.lgooddatepicker.optionalusertools.CalendarBorderProperties;
 import java.awt.*;
 import java.awt.event.*;
@@ -571,12 +571,12 @@ public class CalendarPanel extends JPanel {
                 && (displayedSelectedDate.getYear() == displayedYear)
                 && (displayedSelectedDate.getMonth() == displayedMonth);
         // Set the component colors
-        Color calendarPanelBackgroundColor = settings.getColor(Area.BackgroundOverallCalendarPanel);
+        Color calendarPanelBackgroundColor = settings.getColor(DateArea.BackgroundOverallCalendarPanel);
         setBackground(calendarPanelBackgroundColor);
         headerControlsPanel.setBackground(calendarPanelBackgroundColor);
         monthAndYearOuterPanel.setBackground(calendarPanelBackgroundColor);
         footerPanel.setBackground(calendarPanelBackgroundColor);
-        Color navigationButtonsColor = settings.getColor(Area.BackgroundMonthAndYearNavigationButtons);
+        Color navigationButtonsColor = settings.getColor(DateArea.BackgroundMonthAndYearNavigationButtons);
         if (navigationButtonsColor != null) {
             buttonPreviousYear.setBackground(navigationButtonsColor);
             buttonNextYear.setBackground(navigationButtonsColor);
@@ -680,13 +680,13 @@ public class CalendarPanel extends JPanel {
                 }
                 if (dateIsVetoed) {
                     dateLabel.setEnabled(false);
-                    dateLabel.setBackground(settings.getColor(Area.CalendarBackgroundVetoedDates));
+                    dateLabel.setBackground(settings.getColor(DateArea.CalendarBackgroundVetoedDates));
                     // Note, the foreground color of a disabled date label will always be grey.
                     // So it is not easily possible let the programmer customize that color. 
                 }
                 if ((!dateIsVetoed) && (highlightInfo != null)) {
                     // Set the highlight background color (always).
-                    Color colorBackground = settings.getColor(Area.CalendarDefaultBackgroundHighlightedDates);
+                    Color colorBackground = settings.getColor(DateArea.CalendarDefaultBackgroundHighlightedDates);
                     if (highlightInfo.colorBackground != null) {
                         colorBackground = highlightInfo.colorBackground;
                     }
@@ -741,7 +741,7 @@ public class CalendarPanel extends JPanel {
         }
 
         // Set the background color for the topLeftLabel.
-        topLeftLabel.setBackground(settings.getColor(Area.BackgroundTopLeftLabelAboveWeekNumbers));
+        topLeftLabel.setBackground(settings.getColor(DateArea.BackgroundTopLeftLabelAboveWeekNumbers));
         // Set the background color for the weekday labels.
         for (JLabel weekdayLabel : weekdayLabels) {
             weekdayLabel.setBackground(settings.getColorBackgroundWeekdayLabels());
@@ -888,14 +888,14 @@ public class CalendarPanel extends JPanel {
             return;
         }
         if (label == labelMonth || label == labelYear) {
-            label.setBackground(settings.getColor(Area.BackgroundMonthAndYearMenuButtons));
-            monthAndYearInnerPanel.setBackground(settings.getColor(Area.BackgroundMonthAndYearMenuButtons));
+            label.setBackground(settings.getColor(DateArea.BackgroundMonthAndYearMenuButtons));
+            monthAndYearInnerPanel.setBackground(settings.getColor(DateArea.BackgroundMonthAndYearMenuButtons));
         }
         if (label == labelSetDateToToday) {
-            label.setBackground(settings.getColor(Area.BackgroundTodayButton));
+            label.setBackground(settings.getColor(DateArea.BackgroundTodayButton));
         }
         if (label == labelClearDate) {
-            label.setBackground(settings.getColor(Area.BackgroundClearButton));
+            label.setBackground(settings.getColor(DateArea.BackgroundClearButton));
         }
         label.setBorder(new CompoundBorder(
                 new EmptyBorder(1, 1, 1, 1), labelIndicatorEmptyBorder));

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -5,7 +5,7 @@ import com.privatejgoodies.forms.factories.CC;
 import java.awt.event.*;
 import javax.swing.border.*;
 import com.github.lgooddatepicker.zinternaltools.*;
-import com.github.lgooddatepicker.components.DatePickerSettings.Area;
+import com.github.lgooddatepicker.components.DatePickerSettings.DateArea;
 import com.github.lgooddatepicker.optionalusertools.DateChangeListener;
 import com.github.lgooddatepicker.optionalusertools.PickerUtilities;
 import javax.swing.event.DocumentEvent;
@@ -885,8 +885,8 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
         }
         // Reset all atributes to normal before going further.
         // (Possibility: ValidFullOrEmptyValue)
-        dateTextField.setBackground(settings.getColor(Area.DatePickerTextFieldBackgroundValidDate));
-        dateTextField.setForeground(settings.getColor(Area.DatePickerTextValidDate));
+        dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundValidDate));
+        dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextValidDate));
         dateTextField.setFont(settings.getFontValidDate());
         // Get the text, and check to see if it is empty.
         String dateText = dateTextField.getText();
@@ -896,7 +896,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             if (!settings.getAllowEmptyDates()) {
                 // (Possibility: DisallowedEmptyValue)
                 // Note, there is no text to reflect a foreground or font. 
-                dateTextField.setBackground(settings.getColor(Area.DatePickerTextFieldBackgroundDisallowedEmptyDate));
+                dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisallowedEmptyDate));
             }
             return;
         }
@@ -907,8 +907,8 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
                 settings.getFormatsForParsing(), settings.getLocale());
         if (parsedDate == null) {
             // (Possibility: UnparsableValue)
-            dateTextField.setBackground(settings.getColor(Area.DatePickerTextFieldBackgroundInvalidDate));
-            dateTextField.setForeground(settings.getColor(Area.DatePickerTextInvalidDate));
+            dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundInvalidDate));
+            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextInvalidDate));
             dateTextField.setFont(settings.getFontInvalidDate());
             return;
         }
@@ -917,8 +917,8 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
         boolean isDateVetoed = InternalUtilities.isDateVetoed(vetoPolicy, parsedDate);
         if (isDateVetoed) {
             // (Possibility: VetoedValue)
-            dateTextField.setBackground(settings.getColor(Area.DatePickerTextFieldBackgroundVetoedDate));
-            dateTextField.setForeground(settings.getColor(Area.DatePickerTextVetoedDate));
+            dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundVetoedDate));
+            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextVetoedDate));
             dateTextField.setFont(settings.getFontVetoedDate());
         }
     }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
 public class DatePickerSettings {
 
     /**
-     * Area, These enumerations represent areas of the components whose color can be changed. These
+     * DateArea, These enumerations represent areas of the components whose color can be changed. These
      * values are used with the setColor() function, to set the color of various areas of the
      * DatePicker or the CalendarPanel. The default color for each area is also defined here.
      *
@@ -56,7 +56,7 @@ public class DatePickerSettings {
      * the swing component. The default color for "BackgroundMonthAndYearNavigationButtons" is null,
      * so those buttons will use the default background color supplied by the JButton class.
      */
-    public enum Area {
+    public enum DateArea {
         BackgroundClearButton(new Color(240, 240, 240)),
         BackgroundMonthAndYearMenuButtons(new Color(240, 240, 240)),
         BackgroundMonthAndYearNavigationButtons(null),
@@ -65,15 +65,15 @@ public class DatePickerSettings {
         BackgroundTopLeftLabelAboveWeekNumbers(new Color(184, 207, 229)),
         CalendarDefaultBackgroundHighlightedDates(Color.green),
         CalendarBackgroundVetoedDates(Color.lightGray),
-        DatePickerTextFieldBackgroundDisallowedEmptyDate(Color.pink),
-        DatePickerTextFieldBackgroundInvalidDate(Color.white),
-        DatePickerTextFieldBackgroundValidDate(Color.white),
-        DatePickerTextFieldBackgroundVetoedDate(Color.white),
+        TextFieldBackgroundDisallowedEmptyDate(Color.pink),
+        TextFieldBackgroundInvalidDate(Color.white),
+        TextFieldBackgroundValidDate(Color.white),
+        TextFieldBackgroundVetoedDate(Color.white),
         DatePickerTextInvalidDate(Color.red),
         DatePickerTextValidDate(Color.black),
         DatePickerTextVetoedDate(Color.black);
 
-        Area(Color defaultColor) {
+        DateArea(Color defaultColor) {
             this.defaultColor = defaultColor;
         }
         public Color defaultColor;
@@ -160,7 +160,7 @@ public class DatePickerSettings {
      * getColor() function. By default, this map is populated with a set of default colors. The
      * default colors for each area are defined the "AreaToColor" enum definition.
      */
-    private HashMap<Area, Color> colors;
+    private HashMap<DateArea, Color> colors;
 
     /**
      * enableMonthMenu, This determines whether the month popup menu is enabled or disabled. (Note:
@@ -205,8 +205,8 @@ public class DatePickerSettings {
 
     /**
      * fontInvalidDate, This is the text field text font for invalid dates. The default font is a
-     * normal undecorated font. (Note: The color for invalid dates defaults to Color.red. See also:
-     * setColor() and "Area.DatePickerTextInvalidDate".)
+ normal undecorated font. (Note: The color for invalid dates defaults to Color.red. See also:
+ setColor() and "DateArea.DatePickerTextInvalidDate".)
      */
     private Font fontInvalidDate;
 
@@ -551,8 +551,8 @@ public class DatePickerSettings {
      */
     public DatePickerSettings(Locale pickerLocale) {
         // Add all the default colors to the colors map.
-        colors = new HashMap< Area, Color>();
-        for (Area area : Area.values()) {
+        colors = new HashMap< DateArea, Color>();
+        for (DateArea area : DateArea.values()) {
             colors.put(area, area.defaultColor);
         }
 
@@ -613,7 +613,7 @@ public class DatePickerSettings {
             result.colors = null;
         } else {
             // A shallow copy is okay here, because the map key and value are immutable types.
-            result.colors = new HashMap<Area, Color>(this.colors);
+            result.colors = new HashMap<DateArea, Color>(this.colors);
         }
         result.firstDayOfWeek = this.firstDayOfWeek;
         // The Font class is immutable.
@@ -694,7 +694,7 @@ public class DatePickerSettings {
     /**
      * getColor, This returns the currently set color for the specified area.
      */
-    public Color getColor(Area area) {
+    public Color getColor(DateArea area) {
         return colors.get(area);
     }
 
@@ -1125,7 +1125,7 @@ public class DatePickerSettings {
      * setColor, This sets a color for the specified area. Setting an area to null will restore the
      * default color for that area.
      */
-    public void setColor(Area area, Color color) {
+    public void setColor(DateArea area, Color color) {
         // If null was supplied, then use the default color.
         if (color == null) {
             color = area.defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -798,7 +798,7 @@ public class TimePicker
      * Possibilities list: DisabledComponent, ValidFullOrEmptyValue, UnparsableValue, VetoedValue,
      * DisallowedEmptyValue.
      */
-    private void zDrawTextFieldIndicators() {
+    void zDrawTextFieldIndicators() {
         if (!isEnabled()) {
             // (Possibility: DisabledComponent)
             // Note: The time should always be validated (as if the component lost focus), before
@@ -810,8 +810,8 @@ public class TimePicker
         }
         // Reset all atributes to normal before going further.
         // (Possibility: ValidFullOrEmptyValue)
-        timeTextField.setBackground(Color.white);
-        timeTextField.setForeground(settings.colorTextValidTime);
+        timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundValidTime));
+        timeTextField.setForeground(settings.getColor(TimePickerSettings.Area.TimePickerTextValidTime));
         timeTextField.setFont(settings.fontValidTime);
         // Get the text, and check to see if it is empty.
         String timeText = timeTextField.getText();
@@ -822,7 +822,7 @@ public class TimePicker
                 // (Possibility: ValidFullOrEmptyValue)
             } else {
                 // (Possibility: DisallowedEmptyValue)
-                timeTextField.setBackground(Color.pink);
+                timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundDisallowedEmptyTime));
             }
             return;
         }
@@ -831,7 +831,8 @@ public class TimePicker
                 settings.formatsForParsing, settings.getLocale());
         if (parsedTime == null) {
             // (Possibility: UnparsableValue)
-            timeTextField.setForeground(settings.colorTextInvalidTime);
+            timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundInvalidTime));
+            timeTextField.setForeground(settings.getColor(TimePickerSettings.Area.TimePickerTextInvalidTime));
             timeTextField.setFont(settings.fontInvalidTime);
             return;
         }
@@ -840,7 +841,8 @@ public class TimePicker
         boolean isTimeVetoed = InternalUtilities.isTimeVetoed(vetoPolicy, parsedTime);
         if (isTimeVetoed) {
             // (Possibility: VetoedValue)
-            timeTextField.setForeground(settings.colorTextVetoedTime);
+            timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundVetoedTime));
+            timeTextField.setForeground(settings.getColor(TimePickerSettings.Area.TimePickerTextVetoedTime));
             timeTextField.setFont(settings.fontVetoedTime);
         }
     }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -3,6 +3,7 @@ package com.github.lgooddatepicker.components;
 import com.privatejgoodies.forms.layout.FormLayout;
 import com.privatejgoodies.forms.factories.CC;
 import com.github.lgooddatepicker.zinternaltools.TimeMenuPanel;
+import com.github.lgooddatepicker.components.TimePickerSettings.TimeArea;
 import java.awt.*;
 import javax.swing.border.*;
 import com.github.lgooddatepicker.optionalusertools.PickerUtilities;
@@ -810,8 +811,8 @@ public class TimePicker
         }
         // Reset all atributes to normal before going further.
         // (Possibility: ValidFullOrEmptyValue)
-        timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundValidTime));
-        timeTextField.setForeground(settings.getColor(TimePickerSettings.Area.TimePickerTextValidTime));
+        timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundValidTime));
+        timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextValidTime));
         timeTextField.setFont(settings.fontValidTime);
         // Get the text, and check to see if it is empty.
         String timeText = timeTextField.getText();
@@ -822,7 +823,7 @@ public class TimePicker
                 // (Possibility: ValidFullOrEmptyValue)
             } else {
                 // (Possibility: DisallowedEmptyValue)
-                timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundDisallowedEmptyTime));
+                timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundDisallowedEmptyTime));
             }
             return;
         }
@@ -831,8 +832,8 @@ public class TimePicker
                 settings.formatsForParsing, settings.getLocale());
         if (parsedTime == null) {
             // (Possibility: UnparsableValue)
-            timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundInvalidTime));
-            timeTextField.setForeground(settings.getColor(TimePickerSettings.Area.TimePickerTextInvalidTime));
+            timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundInvalidTime));
+            timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextInvalidTime));
             timeTextField.setFont(settings.fontInvalidTime);
             return;
         }
@@ -841,8 +842,8 @@ public class TimePicker
         boolean isTimeVetoed = InternalUtilities.isTimeVetoed(vetoPolicy, parsedTime);
         if (isTimeVetoed) {
             // (Possibility: VetoedValue)
-            timeTextField.setBackground(settings.getColor(TimePickerSettings.Area.TimePickerTextFieldBackgroundVetoedTime));
-            timeTextField.setForeground(settings.getColor(TimePickerSettings.Area.TimePickerTextVetoedTime));
+            timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundVetoedTime));
+            timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextVetoedTime));
             timeTextField.setFont(settings.fontVetoedTime);
         }
     }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -47,16 +47,24 @@ import javax.swing.border.MatteBorder;
  * the prefix "zDateTimePicker_".
  */
 public class TimePickerSettings {
- public enum Area {
+    /**
+     * TimeArea, These enumerations represent areas of the components whose color can be changed. These
+     * values are used with the setColor() function, to set the color of various areas of the
+     * TimePicker. The default color for each area is also defined here.
+     *
+     * Note: A default color of "null" means that the default color for that element is supplied by
+     * the swing component. 
+     */
+    public enum TimeArea {
         TimePickerTextValidTime(Color.black),
-        TimePickerTextInvalidTime(Color.black),
+        TimePickerTextInvalidTime(Color.red),
         TimePickerTextVetoedTime(Color.black),
-        TimePickerTextFieldBackgroundValidTime(Color.white),
-        TimePickerTextFieldBackgroundInvalidTime(Color.white),
-        TimePickerTextFieldBackgroundVetoedTime(Color.white),
-        TimePickerTextFieldBackgroundDisallowedEmptyTime(Color.pink);
+        TextFieldBackgroundValidTime(Color.white),
+        TextFieldBackgroundInvalidTime(Color.white),
+        TextFieldBackgroundVetoedTime(Color.white),
+        TextFieldBackgroundDisallowedEmptyTime(Color.pink);
         
-        Area(Color defaultColor) {
+        TimeArea(Color defaultColor) {
             this.defaultColor = defaultColor;
         }
         public Color defaultColor;
@@ -97,7 +105,7 @@ public class TimePickerSettings {
      * getColor() function. By default, this map is populated with a set of default colors. The
      * default colors for each area are defined the "AreaToColor" enum definition.
      */
-    private HashMap<TimePickerSettings.Area, Color> colors;
+    private HashMap<TimePickerSettings.TimeArea, Color> colors;
 
     /**
      * displayToggleTimeMenuButton, This controls whether or not the toggle menu button is displayed
@@ -299,8 +307,8 @@ public class TimePickerSettings {
      */
     public TimePickerSettings(Locale timeLocale) {
         // Add all the default colors to the colors map.
-        colors = new HashMap< Area, Color>();
-        for (Area area : Area.values()) {
+        colors = new HashMap< TimeArea, Color>();
+        for (TimeArea area : TimeArea.values()) {
             colors.put(area, area.defaultColor);
         }
         // Save the locale.
@@ -427,7 +435,7 @@ public class TimePickerSettings {
     /**
      * getColor, This returns the currently set color for the specified area.
      */
-    public Color getColor(Area area) {
+    public Color getColor(TimeArea area) {
         return colors.get(area);
     }
 
@@ -584,7 +592,7 @@ public class TimePickerSettings {
             zApplyAllowKeyboardEditing();
         }
     }
-    public void setColor(Area area, Color color) {
+    public void setColor(TimeArea area, Color color) {
         // If null was supplied, then use the default color.
         if (color == null) {
             color = area.defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -17,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeSet;
@@ -46,7 +47,20 @@ import javax.swing.border.MatteBorder;
  * the prefix "zDateTimePicker_".
  */
 public class TimePickerSettings {
-
+ public enum Area {
+        TimePickerTextValidTime(Color.black),
+        TimePickerTextInvalidTime(Color.black),
+        TimePickerTextVetoedTime(Color.black),
+        TimePickerTextFieldBackgroundValidTime(Color.white),
+        TimePickerTextFieldBackgroundInvalidTime(Color.white),
+        TimePickerTextFieldBackgroundVetoedTime(Color.white),
+        TimePickerTextFieldBackgroundDisallowedEmptyTime(Color.pink);
+        
+        Area(Color defaultColor) {
+            this.defaultColor = defaultColor;
+        }
+        public Color defaultColor;
+    }
     /**
      * allowEmptyTimes, This indicates whether or not empty times are allowed in the time picker.
      * Empty times are also called "null times". The default value is true, which allows empty
@@ -76,25 +90,14 @@ public class TimePickerSettings {
      * default, a simple border is drawn.
      */
     public Border borderTimePopup;
-
+    
     /**
-     * colorTextInvalidTime, This is the text field text color for invalid times. The default color
-     * is red.
+     * colors, This hash map holds the current color settings for different areas of the TimePicker.
+     * These colors can be set with the setColor() function, or retrieved with the
+     * getColor() function. By default, this map is populated with a set of default colors. The
+     * default colors for each area are defined the "AreaToColor" enum definition.
      */
-    public Color colorTextInvalidTime = Color.red;
-
-    /**
-     * colorTextValidTime, This is the text field text color for valid times. The default color is
-     * black.
-     */
-    public Color colorTextValidTime = Color.black;
-
-    /**
-     * colorTextVetoedTime, This is the text field text color for vetoed times. The default color is
-     * black. Note: The default fontVetoedTime setting will draw a line (strikethrough) vetoed
-     * times.
-     */
-    public Color colorTextVetoedTime = Color.black;
+    private HashMap<TimePickerSettings.Area, Color> colors;
 
     /**
      * displayToggleTimeMenuButton, This controls whether or not the toggle menu button is displayed
@@ -417,6 +420,13 @@ public class TimePickerSettings {
     }
 
     /**
+     * getColor, This returns the currently set color for the specified area.
+     */
+    public Color getColor(Area area) {
+        return colors.get(area);
+    }
+
+    /**
      * getDisplaySpinnerButtons, Returns the value of this setting. See the "set" function for
      * setting information.
      */
@@ -567,6 +577,18 @@ public class TimePickerSettings {
         this.allowKeyboardEditing = allowKeyboardEditing;
         if (parent != null) {
             zApplyAllowKeyboardEditing();
+        }
+    }
+    public void setColor(Area area, Color color) {
+        // If null was supplied, then use the default color.
+        if (color == null) {
+            color = area.defaultColor;
+        }
+        // Save the color to the color map.
+        colors.put(area, color);
+        // Call any "updating functions" that are appropriate for the specified area.
+        if (parent != null) {
+            parent.zDrawTextFieldIndicators();
         }
     }
 

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -298,6 +298,11 @@ public class TimePickerSettings {
      * supplied locale and language. The constructor populates all the settings with default values.
      */
     public TimePickerSettings(Locale timeLocale) {
+        // Add all the default colors to the colors map.
+        colors = new HashMap< Area, Color>();
+        for (Area area : Area.values()) {
+            colors.put(area, area.defaultColor);
+        }
         // Save the locale.
         this.locale = timeLocale;
 

--- a/Project/src/main/java/com/github/lgooddatepicker/demo/BasicDemo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/demo/BasicDemo.java
@@ -5,6 +5,7 @@ import com.github.lgooddatepicker.components.DatePickerSettings;
 import com.github.lgooddatepicker.components.DateTimePicker;
 import com.github.lgooddatepicker.components.TimePicker;
 import com.github.lgooddatepicker.components.TimePickerSettings;
+import com.github.lgooddatepicker.components.TimePickerSettings.TimeArea;
 import com.github.lgooddatepicker.zinternaltools.InternalUtilities;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -86,7 +87,7 @@ public class BasicDemo extends JFrame {
 
         // Create a time picker with some custom settings.
         TimePickerSettings timeSettings = new TimePickerSettings();
-        timeSettings.setColor(TimePickerSettings.Area.TimePickerTextValidTime, Color.blue);
+        timeSettings.setColor(TimeArea.TimePickerTextValidTime, Color.blue);
         timeSettings.initialTime = LocalTime.now();
         TimePicker timePicker2 = new TimePicker(timeSettings);
         // To display this picker, uncomment this line.

--- a/Project/src/main/java/com/github/lgooddatepicker/demo/BasicDemo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/demo/BasicDemo.java
@@ -86,7 +86,7 @@ public class BasicDemo extends JFrame {
 
         // Create a time picker with some custom settings.
         TimePickerSettings timeSettings = new TimePickerSettings();
-        timeSettings.colorTextValidTime = Color.blue;
+        timeSettings.setColor(TimePickerSettings.Area.TimePickerTextValidTime, Color.blue);
         timeSettings.initialTime = LocalTime.now();
         TimePicker timePicker2 = new TimePicker(timeSettings);
         // To display this picker, uncomment this line.

--- a/Project/src/main/java/com/github/lgooddatepicker/demo/FullDemo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/demo/FullDemo.java
@@ -15,7 +15,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.JPanel;
 import com.github.lgooddatepicker.components.DatePickerSettings;
-import com.github.lgooddatepicker.components.DatePickerSettings.Area;
+import com.github.lgooddatepicker.components.DatePickerSettings.DateArea;
 import com.github.lgooddatepicker.optionalusertools.DateChangeListener;
 import com.github.lgooddatepicker.optionalusertools.PickerUtilities;
 import com.github.lgooddatepicker.zinternaltools.DateChangeEvent;
@@ -169,12 +169,12 @@ public class FullDemo {
 
         // Create a date picker: Change Colors.
         dateSettings = new DatePickerSettings();
-        dateSettings.setColor(Area.BackgroundOverallCalendarPanel, Color.green);
+        dateSettings.setColor(DateArea.BackgroundOverallCalendarPanel, Color.green);
         dateSettings.setColorBackgroundWeekdayLabels(Color.orange, true);
-        dateSettings.setColor(Area.BackgroundMonthAndYearMenuButtons, Color.yellow);
-        dateSettings.setColor(Area.BackgroundTodayButton, Color.yellow);
-        dateSettings.setColor(Area.BackgroundClearButton, Color.yellow);
-        dateSettings.setColor(Area.BackgroundMonthAndYearNavigationButtons, Color.cyan);
+        dateSettings.setColor(DateArea.BackgroundMonthAndYearMenuButtons, Color.yellow);
+        dateSettings.setColor(DateArea.BackgroundTodayButton, Color.yellow);
+        dateSettings.setColor(DateArea.BackgroundClearButton, Color.yellow);
+        dateSettings.setColor(DateArea.BackgroundMonthAndYearNavigationButtons, Color.cyan);
         datePicker = new DatePicker(dateSettings);
         panel.panel1.add(datePicker, getConstraints(1, (row * rowMultiplier), 1));
         panel.addLabel(panel.panel1, 1, (row++ * rowMultiplier), "Date 6, Change Colors:");
@@ -199,7 +199,7 @@ public class FullDemo {
         // Create a date picker: Custom font.
         dateSettings = new DatePickerSettings();
         dateSettings.setFontValidDate(new Font("Monospaced", Font.ITALIC | Font.BOLD, 17));
-        dateSettings.setColor(Area.DatePickerTextValidDate, new Color(0, 100, 0));
+        dateSettings.setColor(DateArea.DatePickerTextValidDate, new Color(0, 100, 0));
         datePicker = new DatePicker(dateSettings);
         datePicker.setDateToToday();
         panel.panel1.add(datePicker, getConstraints(1, (row * rowMultiplier), 1));

--- a/Project/src/main/java/com/github/lgooddatepicker/ysandbox/CalendarPanelAssortmentTest.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/ysandbox/CalendarPanelAssortmentTest.java
@@ -2,7 +2,7 @@ package com.github.lgooddatepicker.ysandbox;
 
 import com.github.lgooddatepicker.components.CalendarPanel;
 import com.github.lgooddatepicker.components.DatePickerSettings;
-import com.github.lgooddatepicker.components.DatePickerSettings.Area;
+import com.github.lgooddatepicker.components.DatePickerSettings.DateArea;
 import com.github.lgooddatepicker.optionalusertools.CalendarBorderProperties;
 import com.github.lgooddatepicker.optionalusertools.DateHighlightPolicy;
 import com.github.lgooddatepicker.optionalusertools.DateVetoPolicy;
@@ -83,14 +83,14 @@ public class CalendarPanelAssortmentTest {
 
         // Create a CalendarPanel: Custom color.
         dateSettings = new DatePickerSettings();
-        dateSettings.setColor(Area.BackgroundOverallCalendarPanel, Color.BLUE);
+        dateSettings.setColor(DateArea.BackgroundOverallCalendarPanel, Color.BLUE);
         dateSettings.setColorBackgroundWeekdayLabels(Color.PINK, true);
         dateSettings.setColorBackgroundWeekNumberLabels(Color.PINK, true);
-        dateSettings.setColor(Area.BackgroundTopLeftLabelAboveWeekNumbers, Color.PINK);
-        dateSettings.setColor(Area.BackgroundMonthAndYearMenuButtons, Color.ORANGE);
-        dateSettings.setColor(Area.BackgroundTodayButton, Color.CYAN);
-        dateSettings.setColor(Area.BackgroundClearButton, Color.GREEN);
-        dateSettings.setColor(Area.BackgroundMonthAndYearNavigationButtons, Color.MAGENTA);
+        dateSettings.setColor(DateArea.BackgroundTopLeftLabelAboveWeekNumbers, Color.PINK);
+        dateSettings.setColor(DateArea.BackgroundMonthAndYearMenuButtons, Color.ORANGE);
+        dateSettings.setColor(DateArea.BackgroundTodayButton, Color.CYAN);
+        dateSettings.setColor(DateArea.BackgroundClearButton, Color.GREEN);
+        dateSettings.setColor(DateArea.BackgroundMonthAndYearNavigationButtons, Color.MAGENTA);
         dateSettings.setWeekNumbersDisplayed(true, true);
         calendarPanel = new CalendarPanel(dateSettings);
         panel.add(calendarPanel);
@@ -211,14 +211,14 @@ public class CalendarPanelAssortmentTest {
         dateSettings = new DatePickerSettings();
         dateSettings.setWeekNumbersDisplayed(true, true);
         calendarPanel = new CalendarPanel(dateSettings);
-        dateSettings.setColor(Area.BackgroundOverallCalendarPanel, Color.BLUE);
+        dateSettings.setColor(DateArea.BackgroundOverallCalendarPanel, Color.BLUE);
         dateSettings.setColorBackgroundWeekdayLabels(Color.PINK, true);
         dateSettings.setColorBackgroundWeekNumberLabels(Color.PINK, true);
-        dateSettings.setColor(Area.BackgroundTopLeftLabelAboveWeekNumbers, Color.PINK);
-        dateSettings.setColor(Area.BackgroundMonthAndYearMenuButtons, Color.ORANGE);
-        dateSettings.setColor(Area.BackgroundTodayButton, Color.CYAN);
-        dateSettings.setColor(Area.BackgroundClearButton, Color.GREEN);
-        dateSettings.setColor(Area.BackgroundMonthAndYearNavigationButtons, Color.MAGENTA);
+        dateSettings.setColor(DateArea.BackgroundTopLeftLabelAboveWeekNumbers, Color.PINK);
+        dateSettings.setColor(DateArea.BackgroundMonthAndYearMenuButtons, Color.ORANGE);
+        dateSettings.setColor(DateArea.BackgroundTodayButton, Color.CYAN);
+        dateSettings.setColor(DateArea.BackgroundClearButton, Color.GREEN);
+        dateSettings.setColor(DateArea.BackgroundMonthAndYearNavigationButtons, Color.MAGENTA);
         panel.add(calendarPanel);
 
         // Create a CalendarPanel: Change first weekday.

--- a/Project/src/main/java/com/github/lgooddatepicker/ysandbox/TestStart.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/ysandbox/TestStart.java
@@ -39,10 +39,10 @@ public class TestStart {
         datePicker = new DatePicker(dateSettings);
         panel.add(datePicker);
         dateSettings.setVetoPolicy(new SampleDateVetoPolicy());
-        dateSettings.setColor(DatePickerSettings.Area.DatePickerTextFieldBackgroundValidDate, Color.green);
-        dateSettings.setColor(DatePickerSettings.Area.DatePickerTextFieldBackgroundInvalidDate, Color.blue);
-        dateSettings.setColor(DatePickerSettings.Area.DatePickerTextFieldBackgroundVetoedDate, Color.orange);
-        dateSettings.setColor(DatePickerSettings.Area.DatePickerTextFieldBackgroundDisallowedEmptyDate, Color.pink);
+        dateSettings.setColor(DatePickerSettings.DateArea.TextFieldBackgroundValidDate, Color.green);
+        dateSettings.setColor(DatePickerSettings.DateArea.TextFieldBackgroundInvalidDate, Color.blue);
+        dateSettings.setColor(DatePickerSettings.DateArea.TextFieldBackgroundVetoedDate, Color.orange);
+        dateSettings.setColor(DatePickerSettings.DateArea.TextFieldBackgroundDisallowedEmptyDate, Color.pink);
         /*
         datePicker = new DatePicker(dateSettings);
         panel.add(datePicker);


### PR DESCRIPTION
New TimePickerSettings Area enums (with the default values):
TimePickerTextValidTime(Color.black),
TimePickerTextInvalidTime(Color.black),
TimePickerTextVetoedTime(Color.black),

TimePickerTextFieldBackgroundValidTime(Color.white),
TimePickerTextFieldBackgroundInvalidTime(Color.white),
TimePickerTextFieldBackgroundVetoedTime(Color.white),
TimePickerTextFieldBackgroundDisallowedEmptyTime(Color.pink),

New TimePickerSettings functions:
setColor (Area area, Color color){}
getColor(){}

Deleted Fields for text foreground color that were replaced by Area enum
colors.