### PR TITLE
Add Automatic-Module-Name to MANIFEST.MF to add basic JSR 376 (Jigsaw…

### DIFF
--- a/Project/src/main/resources/META-INF/MANIFEST.MF
+++ b/Project/src/main/resources/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Archiver-Version: Plexus Archiver
 Built-By: LGoodDatePicker
 Created-By: Apache Maven
 Main-Class: com.github.lgooddatepicker.demo.FullDemo
+Automatic-Module-Name: com.github.lgooddatepicker
 
 Name: com.github.lgooddatepicker.components.DatePicker.class
 Java-Bean: True


### PR DESCRIPTION
…) support

Add Automatic-Module-Name to MANIFEST.MF to make this module usable as JSR 376 module.
This patch reservervs the module name com.github.lgooddatepicker for this project.
To get full support of JSR 376 a module-info.java was required.