### PR TITLE
Fix for issue #60 without enforcing ResolverStyle.STRICT

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -437,7 +437,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
         LocalDate parsedDate = InternalUtilities.getParsedDateOrNull(
                 text, settings.getFormatForDatesCommonEra(),
                 settings.getFormatForDatesBeforeCommonEra(),
-                settings.getFormatsForParsing(), settings.getLocale());
+                settings.getFormatsForParsing());
 
         // If the date could not be parsed, return false.
         if (parsedDate == null) {
@@ -880,7 +880,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             parsedDate = InternalUtilities.getParsedDateOrNull(dateText,
                     settings.getFormatForDatesCommonEra(),
                     settings.getFormatForDatesBeforeCommonEra(),
-                    settings.getFormatsForParsing(), settings.getLocale());
+                    settings.getFormatsForParsing());
         }
         // If the date was parsed successfully, then check it against the veto policy.
         boolean dateIsVetoed = false;
@@ -999,7 +999,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
         LocalDate parsedDate = InternalUtilities.getParsedDateOrNull(dateText,
                 settings.getFormatForDatesCommonEra(),
                 settings.getFormatForDatesBeforeCommonEra(),
-                settings.getFormatsForParsing(), settings.getLocale());
+                settings.getFormatsForParsing());
         if (parsedDate == null) {
             // (Possibility: UnparsableValue)
             dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundInvalidDate));

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -31,7 +31,6 @@ import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
-import java.time.format.ResolverStyle;
 import java.time.temporal.WeekFields;
 import java.util.HashMap;
 import javax.swing.JButton;
@@ -287,18 +286,14 @@ public class DatePickerSettings {
     private Font fontVetoedDate;
 
     /**
-     * formatForDatesCommonEraStrict, This holds the default format that is used to display or parse
-     * CE dates in the date picker. The default value is generated using the locale of the settings
+     * formatForDatesCommonEra, This holds the default format that is used to display or parse CE
+     * dates in the date picker. The default value is generated using the locale of the settings
      * instance.
-     *
-     * Technical Note: In order to avoid validation problems with nonexistent dates like "Feb 31",
-     * all dates used for parsing (including this one), must be saved with ResolverStyle.STRICT.
-     * Therefore these formats will be set to the strict resolver style in their setter functions.
      */
-    private DateTimeFormatter formatForDatesCommonEraStrict;
+    private DateTimeFormatter formatForDatesCommonEra;
 
     /**
-     * formatForDatesBeforeCommonEraStrict, This holds the default format that is used to display or
+     * formatForDatesBeforeCommonEra, This holds the default format that is used to display or
      * parse BCE dates in the date picker. The default value is generated using the locale of the
      * settings instance. A DateTimeFormatter can be created from a pattern string with the
      * convenience function DateUtilities.createFormatterFromPatternString();
@@ -309,12 +304,8 @@ public class DatePickerSettings {
      * "-1" and "1 BC" are not the same thing. Astronomical years are zero-based, and BC dates are
      * one-based. Astronomical year "0", is the same year as "1 BC", and astronomical year "-1" is
      * the same year as "2 BC", and so forth.)
-     *
-     * Technical Note: In order to avoid validation problems with nonexistent dates like "Feb 31",
-     * all dates used for parsing (including this one), must be saved with ResolverStyle.STRICT.
-     * Therefore these formats will be set to the strict resolver style in their setter functions.
      */
-    private DateTimeFormatter formatForDatesBeforeCommonEraStrict;
+    private DateTimeFormatter formatForDatesBeforeCommonEra;
 
     /**
      * formatTodayButton, This format is used to format today's date into a date string, which is
@@ -324,18 +315,14 @@ public class DatePickerSettings {
     private DateTimeFormatter formatForTodayButton;
 
     /**
-     * formatsForParsingStrict, This holds a list of formats that are used to attempt to parse dates
+     * formatsForParsing, This holds a list of formats that are used to attempt to parse dates
      * that are typed by the user. When parsing a date, these formats are tried in the order that
      * they appear in this list. Note that the formatForDatesCommonEra and
      * formatForDatesBeforeCommonEra are always tried (in that order) before any other parsing
      * formats. The default values for the formatsForParsing are generated using the pickerLocale,
      * using the enum constants in java.time.format.FormatStyle.
-     *
-     * Technical Note: In order to avoid validation problems with nonexistent dates like "Feb 31",
-     * all dates used for parsing (including these), must be saved with ResolverStyle.STRICT.
-     * Therefore these formats will be set to the strict resolver style in their setter functions.
      */
-    private ArrayList<DateTimeFormatter> formatsForParsingStrict;
+    private ArrayList<DateTimeFormatter> formatsForParsing;
 
     /**
      * gapBeforeButtonPixels, This specifies the desired width for the gap between the date picker
@@ -718,11 +705,11 @@ public class DatePickerSettings {
         result.fontValidDate = this.fontValidDate;
         result.fontVetoedDate = this.fontVetoedDate;
         // The DateTimeFormatter class is immutable.
-        result.formatForDatesBeforeCommonEraStrict = this.formatForDatesBeforeCommonEraStrict;
-        result.formatForDatesCommonEraStrict = this.formatForDatesCommonEraStrict;
+        result.formatForDatesBeforeCommonEra = this.formatForDatesBeforeCommonEra;
+        result.formatForDatesCommonEra = this.formatForDatesCommonEra;
         result.formatForTodayButton = this.formatForTodayButton;
-        result.formatsForParsingStrict = (this.formatsForParsingStrict == null)
-            ? null : (ArrayList<DateTimeFormatter>) this.formatsForParsingStrict.clone();
+        result.formatsForParsing = (this.formatsForParsing == null)
+            ? null : (ArrayList<DateTimeFormatter>) this.formatsForParsing.clone();
         result.gapBeforeButtonPixels = this.gapBeforeButtonPixels;
         // "result.highlightPolicy" is left at its default value.
         result.isVisibleClearButton = this.isVisibleClearButton;
@@ -963,7 +950,7 @@ public class DatePickerSettings {
      * for setting information.
      */
     public DateTimeFormatter getFormatForDatesBeforeCommonEra() {
-        return formatForDatesBeforeCommonEraStrict;
+        return formatForDatesBeforeCommonEra;
     }
 
     /**
@@ -971,7 +958,7 @@ public class DatePickerSettings {
      * setting information.
      */
     public DateTimeFormatter getFormatForDatesCommonEra() {
-        return formatForDatesCommonEraStrict;
+        return formatForDatesCommonEra;
     }
 
     /**
@@ -987,7 +974,7 @@ public class DatePickerSettings {
      * information.
      */
     public ArrayList<DateTimeFormatter> getFormatsForParsing() {
-        return formatsForParsingStrict;
+        return formatsForParsing;
     }
 
     /**
@@ -1594,8 +1581,7 @@ public class DatePickerSettings {
      * immediate validation of the text field text.
      */
     public void setFormatForDatesBeforeCommonEra(DateTimeFormatter formatForDatesBeforeCommonEra) {
-        this.formatForDatesBeforeCommonEraStrict
-            = formatForDatesBeforeCommonEra.withResolverStyle(ResolverStyle.STRICT);
+        this.formatForDatesBeforeCommonEra = formatForDatesBeforeCommonEra;
         if (parentDatePicker != null) {
             parentDatePicker.setTextFieldToValidStateIfNeeded();
         }
@@ -1644,8 +1630,7 @@ public class DatePickerSettings {
      * picker text field.
      */
     public void setFormatForDatesCommonEra(DateTimeFormatter formatForDatesCommonEra) {
-        this.formatForDatesCommonEraStrict
-            = formatForDatesCommonEra.withResolverStyle(ResolverStyle.STRICT);
+        this.formatForDatesCommonEra = formatForDatesCommonEra;
         if (parentDatePicker != null) {
             parentDatePicker.setTextFieldToValidStateIfNeeded();
         }
@@ -1695,10 +1680,7 @@ public class DatePickerSettings {
      * using the enum constants in java.time.format.FormatStyle.
      */
     public void setFormatsForParsing(ArrayList<DateTimeFormatter> formatsForParsing) {
-        this.formatsForParsingStrict = new ArrayList<DateTimeFormatter>();
-        for (DateTimeFormatter format : formatsForParsing) {
-            this.formatsForParsingStrict.add(format.withResolverStyle(ResolverStyle.STRICT));
-        }
+        this.formatsForParsing = formatsForParsing;
     }
 
     /**

--- a/Project/src/main/java/com/github/lgooddatepicker/ysandbox/TestParsingMatchFunction.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/ysandbox/TestParsingMatchFunction.java
@@ -1,0 +1,148 @@
+package com.github.lgooddatepicker.ysandbox;
+
+import com.github.lgooddatepicker.zinternaltools.InternalUtilities;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
+
+/**
+ * testParsingMatchFunction, This class was written to thoroughly test the effectiveness of the
+ * DatePickerUtilities.doesParsedDateMatchText() function. This class is not involved with the
+ * normal operation of the date pickers.
+ */
+public class TestParsingMatchFunction {
+
+    /**
+     * main, This only exists to run test functions.
+     */
+    public static void main(String[] args) {
+        testDoesParsedDateMatchTextFunction();
+    }
+
+    /**
+     * testDoesParsedDateMatchTextFunction, Test for the function doesParsedDateMatchText(). This
+     * test every valid date between years -10000 and 10000, and also tests all the invalid dates up
+     * to the 31st of short months, in the same range. The tests are done with both alphabetic and
+     * numeric months, and done with BC dates (BC dates have years that are offset from ISO). As of
+     * this writing, the function correctly handles every tested date.
+     */
+    public static void testDoesParsedDateMatchTextFunction() {
+        /**
+         * February - 28 days; 29 days in Leap Years, April - 30 days, June - 30 days, September -
+         * 30 days, November - 30 days.
+         */
+        DateTimeFormatter parseFormat = new DateTimeFormatterBuilder().parseLenient().parseCaseInsensitive().
+                appendPattern("M d, u").toFormatter(Locale.getDefault());
+        DateTimeFormatter parseFormat2 = new DateTimeFormatterBuilder().parseLenient().parseCaseInsensitive().
+                appendPattern("MMMM d, u").toFormatter(Locale.ENGLISH);
+        DateTimeFormatter parseFormatBC = new DateTimeFormatterBuilder().parseLenient().parseCaseInsensitive().
+                appendPattern("MMMM d, yyyy G").toFormatter(Locale.getDefault());
+        Month[] shortMonths = new Month[]{Month.FEBRUARY, Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER};
+        // Make sure that none of short month dates match when given a nonexistent 31st date.
+        for (int year = -10000; year < 10001; ++year) {
+            for (int monthIndex = 0; monthIndex < shortMonths.length; ++monthIndex) {
+                String nonExistantDateString = shortMonths[monthIndex].getValue() + " 31, " + year;
+                LocalDate nonExistantDate = LocalDate.parse(nonExistantDateString, parseFormat);
+                if (InternalUtilities.doesParsedDateMatchText(nonExistantDate, nonExistantDateString, parseFormat)) {
+                    System.out.println("invalid match at " + nonExistantDateString);
+                }
+                String nonExistantDateString2 = shortMonths[monthIndex].name() + " 31, " + year;
+                LocalDate nonExistantDate2 = LocalDate.parse(nonExistantDateString2, parseFormat2);
+                if (InternalUtilities.doesParsedDateMatchText(nonExistantDate2, nonExistantDateString2, parseFormat2)) {
+                    System.out.println("invalid match at " + nonExistantDateString2);
+                }
+            }
+        }
+        // Make sure that February never matches when given a nonexistent 30th date.
+        for (int year = -10000; year < 10001; ++year) {
+            String nonExistantDateString = Month.FEBRUARY.getValue() + " 30, " + year;
+            LocalDate nonExistantDate = LocalDate.parse(nonExistantDateString, parseFormat);
+            if (InternalUtilities.doesParsedDateMatchText(nonExistantDate, nonExistantDateString, parseFormat)) {
+                System.out.println("invalid match at " + nonExistantDateString);
+            }
+            String nonExistantDateString2 = Month.FEBRUARY.name() + " 30, " + year;
+            LocalDate nonExistantDate2 = LocalDate.parse(nonExistantDateString2, parseFormat2);
+            if (InternalUtilities.doesParsedDateMatchText(nonExistantDate2, nonExistantDateString2, parseFormat2)) {
+                System.out.println("invalid match at " + nonExistantDateString2);
+            }
+        }
+        // Make sure that February never matches when given a (nonexistent) 29th date which 
+        // is not on a leap year.
+        for (int year = -10000; year < 10001; ++year) {
+            if (!isLeapYear(year)) {
+                String nonExistantDateString = Month.FEBRUARY.getValue() + " 29, " + year;
+                LocalDate nonExistantDate = LocalDate.parse(nonExistantDateString, parseFormat);
+                if (InternalUtilities.doesParsedDateMatchText(nonExistantDate, nonExistantDateString, parseFormat)) {
+                    System.out.println("invalid match at " + nonExistantDateString);
+                }
+                String nonExistantDateString2 = Month.FEBRUARY.name() + " 29, " + year;
+                LocalDate nonExistantDate2 = LocalDate.parse(nonExistantDateString2, parseFormat2);
+                if (InternalUtilities.doesParsedDateMatchText(nonExistantDate2, nonExistantDateString2, parseFormat2)) {
+                    System.out.println("invalid match at " + nonExistantDateString2);
+                }
+            }
+        }
+        // Make sure that all valid dates give a match.
+        LocalDate validDate = LocalDate.of(-10000, 1, 1);
+        while (validDate.getYear() < 10001) {
+            if (!InternalUtilities.doesParsedDateMatchText(validDate, validDate.toString(), DateTimeFormatter.ISO_DATE)) {
+                System.out.println("invalid mismatch at " + validDate.toString());
+            }
+            String alphabeticDate = validDate.format(parseFormat2);
+            if (!InternalUtilities.doesParsedDateMatchText(validDate, alphabeticDate, parseFormat2)) {
+                System.out.println("invalid mismatch at " + validDate.toString());
+            }
+            validDate = validDate.plusDays(1);
+        }
+        // Make sure that valid BC formatted dates give a match.
+        LocalDate validDateBC = LocalDate.of(-10000, 1, 1);
+        while (validDateBC.getYear() < 5) {
+            String alphabeticDateBC = validDateBC.format(parseFormatBC);
+            if (!InternalUtilities.doesParsedDateMatchText(validDateBC, alphabeticDateBC, parseFormatBC)) {
+                System.out.println("invalid mismatch at " + validDateBC.toString());
+            }
+            validDateBC = validDateBC.plusDays(1);
+        }
+        //Check that Issue #60 was actually resolved
+        checkDate("ddMMyyyy", "30062019", true);
+        checkDate("ddMMyyyy", "31062019", false);
+        checkDate("ddMMuuuu", "30062019", true);
+        checkDate("ddMMuuuu", "31062019", false);
+        checkDate("ddMMyyyyG", "30062019BC", true);
+        checkDate("ddMMyyyyG", "31062019BC", false);
+        checkDate("ddMMyyyyG", "30062019AD", true);
+        checkDate("ddMMyyyyG", "31062019AD", false);
+        checkDate("ddMMuuuuG", "3006-2019BC", true);
+        checkDate("ddMMuuuuG", "3106-2019BC", false);
+        checkDate("ddMMuuuuG", "30062019AD", true);
+        checkDate("ddMMuuuuG", "31062019AD", false);
+        // Indicate that we are finished.
+        System.out.println("done.");
+    }
+
+    static private boolean isLeapYear(int year) {
+        if (year % 4 != 0) {
+            return false;
+        } else if (year % 400 == 0) {
+            return true;
+        } else if (year % 100 == 0) {
+            return false;
+        }
+        return true;
+    }
+
+    static private void checkDate(String dateformat, String dateValue, boolean isValidDate) {
+        final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(dateformat).toFormatter(Locale.ENGLISH);
+        final LocalDate parsedDate = LocalDate.parse(dateValue, formatter);
+        final boolean determinedValidity = InternalUtilities.doesParsedDateMatchText(parsedDate, dateValue, formatter);
+        if (determinedValidity && !isValidDate) {
+            System.out.println("Invalid match at " + dateValue);
+        }
+        if (!determinedValidity && isValidDate) {
+            System.out.println("Invalid mismatch at " + dateValue);
+        }
+    }
+
+}


### PR DESCRIPTION
The changes introduced in release `10.4.1` in commit ee43060 change the behavior of accepted `DateTimeFormatters` by applying `withResolverStyle(ResolverStyle.STRICT)` to all supplied formatters. 
This seems to break existing usages of the API (especially mine :wink:). 
For example: If the supplied format string is "dd/MM/yyyy" as in issue #74. The strict resolver will not resolve this date format as it only supplies `YearOfEra` and not `Year`.
This forces existing users of the API to change their formatters to use "dd/MM/uuuu" or something like "dd/MM/yyyy G" as only these will resolve the era ambiguity of the given year.
To avoid this API breaking change I would like to propose the follwing changes in this pull request:
1. Rolling back the `withResolverStyle(ResolverStyle.STRICT)` changes from  ee43060.
1. Changing `InternalUtilities.doesParsedDateMatchText(...)` to support date formats from issue #60 by employing the `parseUnresolved` functionality of `DateTimeFormatters`.
This change is tested in the `TestParsingMatchFunction` class.
1. Relaxing the requirement for case insensitive `DateTimeFormatters` and thus allow user supplied case sensitive formatters (currently implicitly invalid as all supplied date strings are converted to lowercase).

It would be great if these changes could be incorporated into the next LGoodDatePicker release as this will resolve the issues #60, #74 (seems to be year ambiguity issue) and #76 (seems to be case sensitive resolver issue) while hopefully maintaining API compatibility to release `10.3.1`.

