### PR TITLE
Add new settings for DatePicker labels background and foreground whil…

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -19,7 +19,7 @@ plugins in this file operate inside the "package" and "install" phases.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lgooddatepicker</groupId>
     <artifactId>LGoodDatePicker</artifactId>
-    <version>11.0.2</version>
+    <version>11.1.0</version>
     <packaging>jar</packaging>
     <name>LGoodDatePicker</name>
     <description>Java Swing Date Picker. Easy to use, good looking, nice features, and

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -943,8 +943,8 @@ public class CalendarPanel extends JPanel {
             return;
         }
         // Highlight the label.
-        label.setBackground(settings.getColor(DateArea.BackgroundHoverLabel));
-        label.setForeground(settings.getColor(DateArea.TextHoverLabel));
+        label.setBackground(settings.getColor(DateArea.BackgroundCalendarPanelLabelsOnHover));
+        label.setForeground(settings.getColor(DateArea.TextCalendarPanelLabelsOnHover));
         label.setBorder(new CompoundBorder(
             new LineBorder(Color.GRAY), labelIndicatorEmptyBorder));
     }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -940,7 +940,8 @@ public class CalendarPanel extends JPanel {
             return;
         }
         // Highlight the label.
-        label.setBackground(new Color(184, 207, 229));
+        label.setBackground(settings.getColor(DateArea.BackgroundHoverLabel));
+        label.setForeground(settings.getColor(DateArea.TextHoverLabel));
         label.setBorder(new CompoundBorder(
             new LineBorder(Color.GRAY), labelIndicatorEmptyBorder));
     }
@@ -964,13 +965,16 @@ public class CalendarPanel extends JPanel {
         }
         if (label == labelMonth || label == labelYear) {
             label.setBackground(settings.getColor(DateArea.BackgroundMonthAndYearMenuLabels));
+            label.setForeground(settings.getColor(DateArea.TextMonthAndYearMenuLabels));
             monthAndYearInnerPanel.setBackground(settings.getColor(DateArea.BackgroundMonthAndYearMenuLabels));
         }
         if (label == labelSetDateToToday) {
             label.setBackground(settings.getColor(DateArea.BackgroundTodayLabel));
+            label.setForeground(settings.getColor(DateArea.TextTodayLabel));
         }
         if (label == labelClearDate) {
             label.setBackground(settings.getColor(DateArea.BackgroundClearLabel));
+            label.setForeground(settings.getColor(DateArea.TextClearLabel));
         }
         label.setBorder(new CompoundBorder(
             new EmptyBorder(1, 1, 1, 1), labelIndicatorEmptyBorder));

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -81,7 +81,7 @@ public class DatePickerSettings {
         CalendarTextWeekdays(Color.black),
         CalendarTextWeekNumbers(Color.black),
         TextClearLabel(new JLabel().getForeground()),
-        TextHoverLabel(Color.black),
+        TextHoverLabel(new JLabel().getForeground()),
         TextMonthAndYearMenuLabels(new JLabel().getForeground()),
         TextMonthAndYearNavigationButtons(new JButton().getForeground()),
         TextTodayLabel(new JLabel().getForeground()),
@@ -161,9 +161,9 @@ public class DatePickerSettings {
      * This variable will never be null.
      */
     private ArrayList<CalendarBorderProperties> borderPropertiesList;
-    
+
     /**
-     * clock, A clock used to determine current date and time 
+     * clock, A clock used to determine current date and time
      * The default is to use the System Clock
      */
     private Clock clock = Clock.systemDefaultZone();
@@ -787,7 +787,7 @@ public class DatePickerSettings {
     public ArrayList<CalendarBorderProperties> getBorderPropertiesList() {
         return borderPropertiesList;
     }
-    
+
     /**
      * getClock, Returns the currently set clock
      */
@@ -1192,7 +1192,7 @@ public class DatePickerSettings {
     public boolean getWeekNumbersWillOverrideFirstDayOfWeek() {
         return weekNumbersWillOverrideFirstDayOfWeek;
     }
-    
+
     /**
      * hasParent, This returns true if this settings instance has a parent, otherwise returns false.
      * A settings instance will have a parent if the settings instance has already been used to
@@ -1315,7 +1315,7 @@ public class DatePickerSettings {
             parentCalendarPanel.zApplyBorderPropertiesList();
         }
     }
-    
+
     /**
      * setClock, This sets the clock to use for determining the current
      * date. By default the system clock is used.

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -63,6 +63,7 @@ public class DatePickerSettings {
      */
     public enum DateArea {
         BackgroundClearLabel(new Color(240, 240, 240)),
+        BackgroundHoverLabel(new Color(184, 207, 229)),
         BackgroundMonthAndYearMenuLabels(new Color(240, 240, 240)),
         BackgroundMonthAndYearNavigationButtons(new JButton().getBackground()),
         BackgroundOverallCalendarPanel(new Color(240, 240, 240)),
@@ -78,6 +79,7 @@ public class DatePickerSettings {
         CalendarTextWeekdays(Color.black),
         CalendarTextWeekNumbers(Color.black),
         TextClearLabel(new JLabel().getForeground()),
+        TextHoverLabel(Color.black),
         TextMonthAndYearMenuLabels(new JLabel().getForeground()),
         TextMonthAndYearNavigationButtons(new JButton().getForeground()),
         TextTodayLabel(new JLabel().getForeground()),

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -65,9 +65,9 @@ public class DatePickerSettings {
      */
     public enum DateArea {
         BackgroundClearLabel(new Color(240, 240, 240)),
-        BackgroundHoverLabel(new Color(184, 207, 229)),
         BackgroundMonthAndYearMenuLabels(new Color(240, 240, 240)),
         BackgroundMonthAndYearNavigationButtons(new JButton().getBackground()),
+        BackgroundCalendarPanelLabelsOnHover(new Color(184, 207, 229)),
         BackgroundOverallCalendarPanel(new Color(240, 240, 240)),
         BackgroundTodayLabel(new Color(240, 240, 240)),
         BackgroundTopLeftLabelAboveWeekNumbers(new Color(184, 207, 229)),
@@ -81,10 +81,10 @@ public class DatePickerSettings {
         CalendarTextWeekdays(Color.black),
         CalendarTextWeekNumbers(Color.black),
         TextClearLabel(new JLabel().getForeground()),
-        TextHoverLabel(new JLabel().getForeground()),
         TextMonthAndYearMenuLabels(new JLabel().getForeground()),
         TextMonthAndYearNavigationButtons(new JButton().getForeground()),
         TextTodayLabel(new JLabel().getForeground()),
+        TextCalendarPanelLabelsOnHover(new JLabel().getForeground()),
         TextFieldBackgroundDisallowedEmptyDate(Color.pink),
         TextFieldBackgroundInvalidDate(Color.white),
         TextFieldBackgroundValidDate(Color.white),

--- a/Project/src/test/java/TestFeatures.java
+++ b/Project/src/test/java/TestFeatures.java
@@ -148,7 +148,8 @@ public class TestFeatures
         DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
         CalendarPanel panel = new CalendarPanel(settings);
 
-        final Color generalHighlight = new Color(184,207,229);
+        final Color generalHighlight = settings.getColor(
+                DatePickerSettings.DateArea.BackgroundCalendarPanelLabelsOnHover);
         final Color yearMonthBackground = settings.getColor(DatePickerSettings.DateArea.BackgroundMonthAndYearMenuLabels);
         final Color yearMonthText = settings.getColor(DatePickerSettings.DateArea.TextMonthAndYearMenuLabels);
 
@@ -168,6 +169,35 @@ public class TestFeatures
                 clearLabelText);
     }
 
+        @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomMouseHoverColorCalendarPanel() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException
+    {
+        DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
+        settings.setColor(DatePickerSettings.DateArea.BackgroundCalendarPanelLabelsOnHover, Color.red);
+        settings.setColor(DatePickerSettings.DateArea.TextCalendarPanelLabelsOnHover, Color.yellow);
+        CalendarPanel panel = new CalendarPanel(settings);
+
+        final Color generalHighlight = Color.red;
+        final Color generalHighlightText = Color.yellow;
+        final Color yearMonthBackground = settings.getColor(DatePickerSettings.DateArea.BackgroundMonthAndYearMenuLabels);
+        final Color yearMonthText = settings.getColor(DatePickerSettings.DateArea.TextMonthAndYearMenuLabels);
+
+        verifyLabelHover(panel, "labelMonth", yearMonthBackground, yearMonthText, generalHighlight,
+                generalHighlightText);
+        verifyLabelHover(panel, "labelYear", yearMonthBackground, yearMonthText, generalHighlight,
+                generalHighlightText);
+
+        final Color todayLabelBackground = settings.getColor(DatePickerSettings.DateArea.BackgroundTodayLabel);
+        final Color todayLabelText = settings.getColor(DatePickerSettings.DateArea.TextTodayLabel);
+        verifyLabelHover(panel, "labelSetDateToToday", todayLabelBackground, todayLabelText, generalHighlight,
+                generalHighlightText);
+
+        final Color clearLabelBackground = settings.getColor(DatePickerSettings.DateArea.BackgroundClearLabel);
+        final Color clearLabelText = settings.getColor(DatePickerSettings.DateArea.TextClearLabel);
+        verifyLabelHover(panel, "labelClearDate", clearLabelBackground, clearLabelText, generalHighlight,
+                generalHighlightText);
+    }
+
     void verifyLabelHover(CalendarPanel panel, String labelname, Color defaultBackground, Color defaultText, Color highlightBackground, Color highlightText) throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException
     {
         JLabel labeltoverify = (JLabel)readPrivateField(CalendarPanel.class, panel, labelname);
@@ -184,7 +214,7 @@ public class TestFeatures
         assertTrue(labelname+" has wrong text color: "+labeltoverify.getForeground().toString(), labeltoverify.getForeground().equals(defaultText));
     }
 
-   
+
 
     // helper functions
     Clock getClockFixedToInstant(int year, Month month, int day, int hours, int minutes)
@@ -207,5 +237,5 @@ public class TestFeatures
         return private_method;
     }
 
-   
+
 }


### PR DESCRIPTION
…e hovering

This pull request attempts to provide a a new feature which allows to customise background and foreground of DatePicker labels while hovering.
 - commit a815f5f contains changes to:
      - `DatePickerSettings` class to add two new DateArea settings
      - `CalendarPanel` to change behaviour of hover event and change to default state methods