### PR TITLE
Add support for custom Clock

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -148,7 +148,7 @@ public class CalendarPanel extends JPanel {
      * displayedYearMonth, This stores the currently displayed year and month. This defaults to the
      * current year and month. This will never be null.
      */
-    private YearMonth displayedYearMonth = YearMonth.now();
+    private YearMonth displayedYearMonth = null;
 
     /**
      * isIndependentCalendarPanel, This indicates whether or not this is an independent calendar
@@ -249,6 +249,9 @@ public class CalendarPanel extends JPanel {
         boolean isIndependentCalendarPanelInstance) {
         // Save the information of whether this is an independent calendar panel.
         this.isIndependentCalendarPanel = isIndependentCalendarPanelInstance;
+        
+        displayedYearMonth = YearMonth.now(datePickerSettings.getClock());
+        
         // Call the JFormDesigner managed initialization function.
         initComponents();
         // Add needed mouse listeners to the today and clear buttons. 
@@ -811,12 +814,12 @@ public class CalendarPanel extends JPanel {
         setSizeOfWeekNumberLabels();
 
         // Set the label for the today button.
-        String todayDateString = settings.getFormatForTodayButton().format(LocalDate.now());
+        String todayDateString = settings.getFormatForTodayButton().format(LocalDate.now(settings.getClock()));
         String todayLabel = settings.getTranslationToday() + ":  " + todayDateString;
         labelSetDateToToday.setText(todayLabel);
         // If today is vetoed, disable the today button.
         boolean todayIsVetoed = InternalUtilities.isDateVetoed(
-            vetoPolicy, LocalDate.now());
+            vetoPolicy, LocalDate.now(settings.getClock()));
         labelSetDateToToday.setEnabled(!todayIsVetoed);
 
         // Set the visibility of all the calendar control buttons (and button labels).
@@ -926,7 +929,7 @@ public class CalendarPanel extends JPanel {
         // Do not highlight the today label if today is vetoed.
         if (label == labelSetDateToToday) {
             DateVetoPolicy vetoPolicy = settings.getVetoPolicy();
-            boolean todayIsVetoed = InternalUtilities.isDateVetoed(vetoPolicy, LocalDate.now());
+            boolean todayIsVetoed = InternalUtilities.isDateVetoed(vetoPolicy, LocalDate.now(settings.getClock()));
             if (todayIsVetoed) {
                 return;
             }
@@ -1017,7 +1020,7 @@ public class CalendarPanel extends JPanel {
      * date picker. This sets the date picker date to today.
      */
     private void labelSetDateToTodayMousePressed(MouseEvent e) {
-        userSelectedADate(LocalDate.now());
+        userSelectedADate(LocalDate.now(settings.getClock()));
     }
 
     /**
@@ -1095,7 +1098,7 @@ public class CalendarPanel extends JPanel {
     public void setSelectedDate(LocalDate selectedDate) {
         setSelectedDateWithoutShowing(selectedDate);
         YearMonth yearMonthToShow
-            = (selectedDate == null) ? YearMonth.now() : YearMonth.from(selectedDate);
+            = (selectedDate == null) ? YearMonth.now(settings.getClock()) : YearMonth.from(selectedDate);
         setDisplayedYearMonth(yearMonthToShow);
     }
 

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -568,7 +568,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
      * additional details.
      */
     public void setDateToToday() {
-        setDate(LocalDate.now());
+        setDate(LocalDate.now(settings.getClock()));
     }
 
     /**

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -25,6 +25,8 @@ import java.awt.Point;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
+
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -157,6 +159,12 @@ public class DatePickerSettings {
      * This variable will never be null.
      */
     private ArrayList<CalendarBorderProperties> borderPropertiesList;
+    
+    /**
+     * clock, A clock used to determine current date and time 
+     * The default is to use the System Clock
+     */
+    private Clock clock = Clock.systemDefaultZone();
 
     /**
      * colorBackgroundWeekdayLabels, This is the calendar background color for the weekday labels.
@@ -777,6 +785,13 @@ public class DatePickerSettings {
     public ArrayList<CalendarBorderProperties> getBorderPropertiesList() {
         return borderPropertiesList;
     }
+    
+    /**
+     * getClock, Returns the currently set clock
+     */
+    public Clock getClock() {
+    	return clock;
+    }
 
     /**
      * getColor, This returns the currently set color for the specified area.
@@ -1175,7 +1190,7 @@ public class DatePickerSettings {
     public boolean getWeekNumbersWillOverrideFirstDayOfWeek() {
         return weekNumbersWillOverrideFirstDayOfWeek;
     }
-
+    
     /**
      * hasParent, This returns true if this settings instance has a parent, otherwise returns false.
      * A settings instance will have a parent if the settings instance has already been used to
@@ -1297,6 +1312,15 @@ public class DatePickerSettings {
         if (parentCalendarPanel != null) {
             parentCalendarPanel.zApplyBorderPropertiesList();
         }
+    }
+    
+    /**
+     * setClock, This sets the clock to use for determining the current
+     * date. By default the system clock is used.
+     * @param clock A clock to use
+     */
+    public void setClock(Clock clock) {
+    	this.clock = clock;
     }
 
     /**
@@ -2171,7 +2195,7 @@ public class DatePickerSettings {
         LocalDate selectedDate = zGetParentSelectedDate();
         if ((!allowEmptyDates) && (selectedDate == null)) {
             // We need to initialize the current date, so find out if today is vetoed.
-            LocalDate today = LocalDate.now();
+            LocalDate today = LocalDate.now(clock);
             if (InternalUtilities.isDateVetoed(vetoPolicy, today)) {
                 throw new RuntimeException("Exception in DatePickerSettings.zApplyAllowEmptyDates(), "
                     + "Could not initialize a null date to today, because today is vetoed by "
@@ -2301,7 +2325,7 @@ public class DatePickerSettings {
      * YearMonth.now() for any null value. This will never return null.
      */
     YearMonth zGetDefaultYearMonthAsUsed() {
-        return (defaultYearMonth == null) ? YearMonth.now() : defaultYearMonth;
+        return (defaultYearMonth == null) ? YearMonth.now(clock) : defaultYearMonth;
     }
 
     /**

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -12,6 +12,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.font.TextAttribute;
+import java.time.Clock;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -100,6 +101,12 @@ public class TimePickerSettings {
      * default, a simple border is drawn.
      */
     public Border borderTimePopup;
+    
+    /**
+     * clock, A clock used to determine current date and time 
+     * The default is to use the System Clock
+     */
+    private Clock clock = Clock.systemDefaultZone();
 
     /**
      * colors, This hash map holds the current color settings for different areas of the TimePicker.
@@ -433,6 +440,13 @@ public class TimePickerSettings {
     public boolean getAllowKeyboardEditing() {
         return allowKeyboardEditing;
     }
+    
+    /**
+     * getClock, Returns the currently set clock
+     */
+    public Clock getClock() {
+    	return clock;
+    }
 
     /**
      * getColor, This returns the currently set color for the specified area.
@@ -594,6 +608,15 @@ public class TimePickerSettings {
             zApplyAllowKeyboardEditing();
         }
     }
+    
+    /**
+     * setClock, This sets the clock to use for determining the current
+     * date. By default the system clock is used.
+     * @param clock A clock to use
+     */
+    public void setClock(Clock clock) {
+    	this.clock = clock;
+    }
 
     /**
      * setColor, This sets a color for the specified area. Setting an area to null will restore the
@@ -720,7 +743,7 @@ public class TimePickerSettings {
      * function only has an effect before the time picker is constructed.
      */
     public void setInitialTimeToNow() {
-        initialTime = LocalTime.now();
+        initialTime = LocalTime.now(clock);
     }
 
     /**


### PR DESCRIPTION
Allows an optional Clock to be set in the DateSettings and TimeSettings.  This clock is used by the DatePicker and TimePicker to determine the current date/time.

This change allows the utility to work in environments where the current time is not tied to the System clock. For example, testing, or working with historical data.