### PR TITLE
Added new deploy profile to pom and refactored build steps

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- -->
-<!-- To build for Maven Central: 
-(Note: Only the primary developers should ever need to build for Maven Central. 
+<!-- To build for Maven Central:
+(Note: Only the primary developers should ever need to build for Maven Central.
 All other people and programmers can ignore this paragraph.)
-To build for Maven Central, with GPG signing, you will have to uncomment all 
+To build for Maven Central, with GPG signing, you will have to uncomment all
 sections of this pom file that are marked with the word "signing".
 -->
 <!-- -->
 <!-- General notes:
-The ordering of the plugins in this file matters. The execution order for any plugin executions 
-that are on the same phase will be the same as the order of entries in the pom file. Multiple 
+The ordering of the plugins in this file matters. The execution order for any plugin executions
+that are on the same phase will be the same as the order of entries in the pom file. Multiple
 plugins in this file operate inside the "package" and "install" phases.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lgooddatepicker</groupId>
@@ -22,7 +22,7 @@ plugins in this file operate inside the "package" and "install" phases.
     <version>10.4.1</version>
     <packaging>jar</packaging>
     <name>LGoodDatePicker</name>
-    <description>Java Swing Date Picker. Easy to use, good looking, nice features, and 
+    <description>Java Swing Date Picker. Easy to use, good looking, nice features, and
         localized. Uses the JSR-310 standard.</description>
     <url>https://github.com/LGoodDatePicker/LGoodDatePicker</url>
     <licenses>
@@ -44,32 +44,32 @@ plugins in this file operate inside the "package" and "install" phases.
         <developerConnection>scm:git:git@github.com:LGoodDatePicker/LGoodDatePicker.git</developerConnection>
         <url>git@github.com:LGoodDatePicker/LGoodDatePicker.git</url>
     </scm>
-    
+
     <!-- ## Instructions for switching between Java 1.8 releases, and Java 1.6 releases. ##
         Note: The project should only be committed to the GitHub master branch, while configured
         for Java 1.8.
-        
+
         * For Java 1.6:
         * In the POM properties section: Switch the maven source and target to 1.6.
         * In the POM dependencies section: Uncomment the dependency section for "threetenbp".
-        * Replace the following string in all the project source files: 
+        * Replace the following string in all the project source files:
           - "import java(dot)time" with "import org.threeten(dot)bp".
-        
+
         * For Java 1.8:
         * In the POM properties section: Switch the maven source and target to 1.8.
         * In the POM dependencies section: Comment out the dependency section for "threetenbp".
-        * Replace the following string in all the project source files: 
+        * Replace the following string in all the project source files:
           - "import org.threeten(dot)bp" with "import java(dot)time".
     -->
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-    
+
     <dependencies>
-        
+
         <!-- JSRThreeTen Backport. Uncomment this section when building for target Java 1.6. -->
         <!--
         <dependency>
@@ -78,14 +78,15 @@ plugins in this file operate inside the "package" and "install" phases.
             <version>1.3.1</version>
         </dependency>
         -->
-       
-        <!-- BeansBinding, This is only used in the data binding demo. -->
+
+        <!-- BeansBinding, This is only used in the data binding demo.
+             uncomment this if you want to compile the data binding demo
         <dependency>
             <groupId>org.jdesktop</groupId>
             <artifactId>beansbinding</artifactId>
             <version>1.2.1</version>
-        </dependency>
-        
+        </dependency> -->
+
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>
@@ -93,11 +94,103 @@ plugins in this file operate inside the "package" and "install" phases.
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
-    
+
+    <profiles>
+        <!-- Deployment profile used so signing plugin is only used when deploying -->
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <!-- GPG plugin -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Prevent `gpg` from using pinentry programs -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deployinstall</id>
+                                <phase>install</phase>
+                                <configuration>
+                                    <tasks>
+                                        <echo message = ">>>>>>>>>>>>>>>>>>>>>>>>>>>> install (deploy)"/>
+                                        <delete file="${project.build.directory}/${project.artifactId}-${project.version}.pom.asc"/>
+                                        <copy file="${project.build.directory}/pom-for-users.txt.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}.pom.asc"/>
+                                        <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}-unshaded-for-backport.jar.asc"/>
+                                        <delete file="${project.build.directory}/${project.artifactId}-${project.version}.jar.asc"/>
+                                        <copy file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}.jar.asc"/>
+                                        <copy file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}-executable-demo.jar.asc"/>
+
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>createbundle</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${env.JAVA_HOME}/bin/jar</executable>
+                                    <workingDirectory>${project.build.directory}</workingDirectory>
+                                    <arguments>
+                                        <argument>-cvf</argument>
+                                        <argument>Bundle-${project.artifactId}-${project.version}.jar</argument>
+                                        <argument>${project.artifactId}-${project.version}.pom</argument>
+                                        <argument>${project.artifactId}-${project.version}.pom.asc</argument>
+                                        <argument>${project.artifactId}-${project.version}.jar</argument>
+                                        <argument>${project.artifactId}-${project.version}.jar.asc</argument>
+                                        <argument>${project.artifactId}-${project.version}-executable-demo.jar</argument>
+                                        <argument>${project.artifactId}-${project.version}-executable-demo.jar.asc</argument>
+                                        <argument>${project.artifactId}-${project.version}-javadoc.jar</argument>
+                                        <argument>${project.artifactId}-${project.version}-javadoc.jar.asc</argument>
+                                        <argument>${project.artifactId}-${project.version}-sources.jar</argument>
+                                        <argument>${project.artifactId}-${project.version}-sources.jar.asc</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin> -->
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
-        
+
         <resources>
             <resource>
                 <!-- This turns on resource filtering so we can get the version number at runtime. -->
@@ -105,9 +198,9 @@ plugins in this file operate inside the "package" and "install" phases.
                 <filtering>true</filtering>
             </resource>
         </resources>
-        
+
         <plugins>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -119,7 +212,7 @@ plugins in this file operate inside the "package" and "install" phases.
                     </compilerArgs>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -133,7 +226,7 @@ plugins in this file operate inside the "package" and "install" phases.
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -152,7 +245,7 @@ plugins in this file operate inside the "package" and "install" phases.
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -180,12 +273,12 @@ plugins in this file operate inside the "package" and "install" phases.
                                     <file>src/main/resources/META-INF/MANIFEST.MF</file>
                                 </transformer>
                             </transformers>
-                            <minimizeJar>true</minimizeJar> 
+                            <minimizeJar>true</minimizeJar>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
@@ -195,7 +288,7 @@ plugins in this file operate inside the "package" and "install" phases.
                         <configuration>
                             <tasks>
                                 <echo message = ">>>>>>>>>>>>>>>>>>>>>>>>>>>>package"/>
-                                <copy file="${basedir}/target/classes/pom-for-users.txt" tofile="${project.build.directory}/pom-for-users.xml"/>
+                                <copy file="${basedir}/target/classes/pom-for-users.txt" tofile="${project.build.directory}/pom-for-users.txt"/>
                             </tasks>
                         </configuration>
                         <goals>
@@ -208,29 +301,13 @@ plugins in this file operate inside the "package" and "install" phases.
                         <configuration>
                             <tasks>
                                 <echo message = ">>>>>>>>>>>>>>>>>>>>>>>>>>>>install"/>
-                           
-                                <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar" tofile="${project.build.directory}/${project.artifactId}-${project.version}-unshaded-for-backport.jar"/>
-                               
-                                <delete file="${project.build.directory}/${project.artifactId}-${project.version}.jar"/> 
                                 <delete file="${project.build.directory}/${project.artifactId}-${project.version}.pom"/>
+                                <copy file="${project.build.directory}/pom-for-users.txt" tofile="${project.build.directory}/${project.artifactId}-${project.version}.pom"/>
+                                <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar" tofile="${project.build.directory}/${project.artifactId}-${project.version}-unshaded-for-backport.jar"/>
+                                <delete file="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
                                 <copy file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar" tofile="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
                                 <copy file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar" tofile="${project.build.directory}/${project.artifactId}-${project.version}-executable-demo.jar"/>
-                                <delete file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar"/>
-                                <copy file="${project.build.directory}/pom-for-users.xml" tofile="${project.build.directory}/${project.artifactId}-${project.version}.pom"/>
-                                <delete file="${project.build.directory}/pom-for-users.xml"/>
-                                
-                                <!-- Uncomment this section for Maven signing. -->
-                                <!-- 
-                                <delete file="${project.build.directory}/${project.artifactId}-${project.version}.jar.asc"/>
-                                <delete file="${project.build.directory}/${project.artifactId}-${project.version}.pom.asc"/>
-                                <copy file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}.jar.asc"/>
-                                <copy file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}-executable-demo.jar.asc"/>
-                                <delete file="${project.build.directory}/${project.artifactId}-${project.version}-core.jar.asc"/>                              
-                                <copy file="${project.build.directory}/pom-for-users.xml.asc" tofile="${project.build.directory}/${project.artifactId}-${project.version}.pom.asc"/>
-                                <delete file="${project.build.directory}/pom-for-users.xml.asc"/>
-                                -->
-                                
-                                
+
                             </tasks>
                         </configuration>
                         <goals>
@@ -239,7 +316,7 @@ plugins in this file operate inside the "package" and "install" phases.
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -254,7 +331,7 @@ plugins in this file operate inside the "package" and "install" phases.
                         <configuration>
                             <artifacts>
                                 <artifact>
-                                    <file>${project.build.directory}/pom-for-users.xml</file>
+                                    <file>${project.build.directory}/pom-for-users.txt</file>
                                     <type>pom</type>
                                 </artifact>
                             </artifacts>
@@ -262,68 +339,32 @@ plugins in this file operate inside the "package" and "install" phases.
                     </execution>
                 </executions>
             </plugin>
-            
-            <!-- NOTE 1: Remove this plugin if you don't need to sign the jar for Maven Central release. -->
-            <!-- NOTE 2: This will generate a warning, that can be ignored: -->
-            <!-- "Artifact com.github.lgooddatepicker:LGoodDatePicker:pom.asc:4.2.2 already attached to project, ignoring duplicate" -->
-            <!-- The "exec-maven-plugin"  must be positioned in the pom file after all other 
-            plugins on the "install" phase. -->
-            
-            <!-- Uncomment these two plugin sections for Maven signing. (maven-gpg-plugin and exec-maven-plugin). -->
-            <!-- 
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <keyname>${gpg.keyname}</keyname>
-                            <passphraseServerId>${gpg.keyname}</passphraseServerId>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.4.0</version>
-                <executions>
-                    <execution>
-                        <id>createbundle</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${env.JAVA_HOME}/bin/jar</executable>
-                            <workingDirectory>${project.build.directory}</workingDirectory>
-                            <arguments>
-                                <argument>-cvf</argument>
-                                <argument>Bundle-${project.artifactId}-${project.version}.jar</argument>
-                                <argument>${project.artifactId}-${project.version}.pom</argument>
-                                <argument>${project.artifactId}-${project.version}.pom.asc</argument>
-                                <argument>${project.artifactId}-${project.version}.jar</argument>
-                                <argument>${project.artifactId}-${project.version}.jar.asc</argument>
-                                <argument>${project.artifactId}-${project.version}-executable-demo.jar</argument>
-                                <argument>${project.artifactId}-${project.version}-executable-demo.jar.asc</argument>
-                                <argument>${project.artifactId}-${project.version}-javadoc.jar</argument>
-                                <argument>${project.artifactId}-${project.version}-javadoc.jar.asc</argument>
-                                <argument>${project.artifactId}-${project.version}-sources.jar</argument>
-                                <argument>${project.artifactId}-${project.version}-sources.jar.asc</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
-            
+
         </plugins>
     </build>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
 </project>
 


### PR DESCRIPTION
This *PR* refactores the main `pom.xml` file:
* a new deploy profile was introduced to avoid commenting code in and out for deployment
* the inactive dependency to `org.jdesktop.beansbinding` was commented out
* the artifact deployment is now done via  `org.sonatype.plugins.nexus-staging-maven-plugin`
* the renaming and copying of files had to be moved around to work with the `nexus-staging-maven-plugin`