### PR TITLE
Release preparations

### DIFF
--- a/.github/workflows/mavenpublishcentral.yml
+++ b/.github/workflows/mavenpublishcentral.yml
@@ -1,10 +1,14 @@
 name: Publish release to Maven Central Repository
 
-# Run workflow on commits to the `releases` branch (used for debugging first steps)
+# Run workflow for every prerelease and published release
 on:
-  push:
-    branches:
-      - releases
+  release:
+    types: [prereleased, published]
+# if you want to debug the deployment workflow you can run this workflow for every commit on a branch (e.g. releases)
+#on:
+  #push:
+  #  branches:
+  #    - releases
 
 jobs:
   release:
@@ -19,7 +23,7 @@ jobs:
           java-version: 1.8
 
       - name: Release Maven package
-        uses: samuelmeuli/action-maven-publish@v1.4
+        uses: samuelmeuli/action-maven-publish@v1.4.0
         with:
           gpg_private_key: ${{ secrets.MVN_GPG_SIGN_SECRET_KEY }}
           gpg_passphrase: ${{ secrets.MVN_GPG_SIGN_PASSPHRASE }}

--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -19,7 +19,7 @@ plugins in this file operate inside the "package" and "install" phases.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lgooddatepicker</groupId>
     <artifactId>LGoodDatePicker</artifactId>
-    <version>10.4.1</version>
+    <version>11.0.0</version>
     <packaging>jar</packaging>
     <name>LGoodDatePicker</name>
     <description>Java Swing Date Picker. Easy to use, good looking, nice features, and


### PR DESCRIPTION
This *PR* bumps the version number to `11.0.0` and fixes the following Maven Central publishing workflow issues:
* fix version number of *github* action dependency
* change execution event for Maven Central publishing workflow to be executed for every release