### PR TITLE
Add tests for custom clock feature

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -19,7 +19,7 @@ plugins in this file operate inside the "package" and "install" phases.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lgooddatepicker</groupId>
     <artifactId>LGoodDatePicker</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
     <name>LGoodDatePicker</name>
     <description>Java Swing Date Picker. Easy to use, good looking, nice features, and

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -249,12 +249,12 @@ public class CalendarPanel extends JPanel {
         boolean isIndependentCalendarPanelInstance) {
         // Save the information of whether this is an independent calendar panel.
         this.isIndependentCalendarPanel = isIndependentCalendarPanelInstance;
-        
-        displayedYearMonth = YearMonth.now(datePickerSettings.getClock());
-        
+
+        displayedYearMonth = YearMonth.now(getClockForToday());
+
         // Call the JFormDesigner managed initialization function.
         initComponents();
-        // Add needed mouse listeners to the today and clear buttons. 
+        // Add needed mouse listeners to the today and clear buttons.
         zAddMouseListenersToTodayAndClearButtons();
         // Create the yearTextField, and add it to the yearEditorPanel.
         yearTextField = new JIntegerTextField(4);
@@ -284,7 +284,7 @@ public class CalendarPanel extends JPanel {
         buttonNextMonth.setMargin(new java.awt.Insets(1, 2, 1, 2));
 
         // Generate and add the various calendar panel labels.
-        // These are only generated once. 
+        // These are only generated once.
         addDateLabels();
         addWeekdayLabels();
         addTopLeftLabel();
@@ -318,7 +318,7 @@ public class CalendarPanel extends JPanel {
         // The array index is based on the border label index (not the cell location).
         int[] labelLocations_X_forColumn = new int[]{0, 1, 2, 3, 4, 11};
         int[] labelLocations_Y_forRow = new int[]{0, 1, 2, 5, 6, 12};
-        // These integers represent the dimensions of every border label. 
+        // These integers represent the dimensions of every border label.
         // Note that some dimension combinations from these arrays are not used.
         // The array index is based on the border label index (not the cell location).
         int[] labelWidthsInCells_forColumn = new int[]{0, 1, 1, 1, 7, 1};
@@ -337,8 +337,8 @@ public class CalendarPanel extends JPanel {
             Dimension labelSizeInCells = new Dimension(labelWidthsInCells_forColumn[index.x],
                 labelHeightsInCells_forRow[index.y]);
             JLabel label = new JLabel();
-            // The only properties we need on instantiation are that the label is opaque, and 
-            // that it is not visible by default. The other default border properties will be 
+            // The only properties we need on instantiation are that the label is opaque, and
+            // that it is not visible by default. The other default border properties will be
             // set later.
             label.setOpaque(true);
             label.setVisible(false);
@@ -570,10 +570,10 @@ public class CalendarPanel extends JPanel {
         this.displayedYearMonth = newYearMonth;
 
         // Notify any CalendarListeners of a possible change to the YearMonth.
-        // Note: It is intentional that this section of code does not have it's own function, 
-        // because this should not be called from anywhere else. 
-        // Note: this is placed at the beginning of the drawCalendar function, so that if desired, 
-        // a developer could change the appearance of the calendar in response to this event. 
+        // Note: It is intentional that this section of code does not have it's own function,
+        // because this should not be called from anywhere else.
+        // Note: this is placed at the beginning of the drawCalendar function, so that if desired,
+        // a developer could change the appearance of the calendar in response to this event.
         for (CalendarListener calendarListener : calendarListeners) {
             YearMonthChangeEvent yearMonthChangeEvent = new YearMonthChangeEvent(
                 this, this.displayedYearMonth, oldYearMonth);
@@ -613,27 +613,27 @@ public class CalendarPanel extends JPanel {
         buttonNextYear.setBackground(navigationButtonsColor);
         buttonPreviousMonth.setBackground(navigationButtonsColor);
         buttonNextMonth.setBackground(navigationButtonsColor);
-        // Set the fonts of all buttons. 
+        // Set the fonts of all buttons.
         buttonPreviousYear.setFont(settings.getFontMonthAndYearNavigationButtons());
         buttonNextYear.setFont(settings.getFontMonthAndYearNavigationButtons());
         buttonPreviousMonth.setFont(settings.getFontMonthAndYearNavigationButtons());
         buttonNextMonth.setFont(settings.getFontMonthAndYearNavigationButtons());
-        // Set the font-colors of all buttons. 
+        // Set the font-colors of all buttons.
         buttonPreviousYear.setForeground(settings.getColor(DateArea.TextMonthAndYearNavigationButtons));
         buttonNextYear.setForeground(settings.getColor(DateArea.TextMonthAndYearNavigationButtons));
         buttonPreviousMonth.setForeground(settings.getColor(DateArea.TextMonthAndYearNavigationButtons));
         buttonNextMonth.setForeground(settings.getColor(DateArea.TextMonthAndYearNavigationButtons));
-        // Set the fonts of all labels. 
+        // Set the fonts of all labels.
         labelMonth.setFont(settings.getFontMonthAndYearMenuLabels());
         labelYear.setFont(settings.getFontMonthAndYearMenuLabels());
         labelSetDateToToday.setFont(settings.getFontTodayLabel());
         labelClearDate.setFont(settings.getFontClearLabel());
-        // Set the font-colors of all labels. 
+        // Set the font-colors of all labels.
         labelMonth.setForeground(settings.getColor(DateArea.TextMonthAndYearMenuLabels));
         labelYear.setForeground(settings.getColor(DateArea.TextMonthAndYearMenuLabels));
         labelSetDateToToday.setForeground(settings.getColor(DateArea.TextTodayLabel));
         labelClearDate.setForeground(settings.getColor(DateArea.TextClearLabel));
-        // Set the month and the year label text values. 
+        // Set the month and the year label text values.
         // Use the short month if the user is currently using the keyboard editor for the year.
         if (monthAndYearInnerPanel.isAncestorOf(yearEditorPanel)) {
             labelMonth.setText(localizedShortMonth);
@@ -644,7 +644,7 @@ public class CalendarPanel extends JPanel {
         labelYear.setText(displayedYearString);
         if (!displayedYearString.equals(yearTextField.getText())) {
             // This invokeLater call fixes a bug where an exception was being thrown if you typed
-            // "0X" into the year text field. The exception was: 
+            // "0X" into the year text field. The exception was:
             // "IllegalStateException: Attempt to mutate in notification".
             SwingUtilities.invokeLater(new Runnable() {
                 @Override
@@ -704,12 +704,12 @@ public class CalendarPanel extends JPanel {
                 LocalDate currentDate = LocalDate.of(displayedYear, displayedMonth, dayOfMonth);
 
                 // Save the first date of each used calendar row, for getting week numbers.
-                // Notes: The first day of the month will always be in the first row. 
+                // Notes: The first day of the month will always be in the first row.
                 // The first day of the month will only occur once while inside the valid range.
                 if (dayOfMonth == 1) {
-                    // The first date of the first row will often be a date from the previous month. 
+                    // The first date of the first row will often be a date from the previous month.
                     // The first date label will often not have a displayed date.
-                    // We encompass this in a try block, so that LocalDate.MIN will not throw an 
+                    // We encompass this in a try block, so that LocalDate.MIN will not throw an
                     // exception here.
                     try {
                         LocalDate firstDateOfFirstRow = currentDate.minusDays(dateLabelArrayIndex);
@@ -718,7 +718,7 @@ public class CalendarPanel extends JPanel {
                         firstDateInEachUsedRow.add(LocalDate.MIN);
                     }
                 } else if ((dateLabelArrayIndex % 7) == 0) {
-                    // If we are not in the first row, and we are in the first label of a row, then 
+                    // If we are not in the first row, and we are in the first label of a row, then
                     // add the current date to the firstDateInEachRow array.
                     firstDateInEachUsedRow.add(currentDate);
                 }
@@ -733,7 +733,7 @@ public class CalendarPanel extends JPanel {
                     dateLabel.setEnabled(false);
                     dateLabel.setBackground(settings.getColor(DateArea.CalendarBackgroundVetoedDates));
                     // Note, the foreground color of a disabled date label will always be grey.
-                    // So it is not easily possible let the programmer customize that color. 
+                    // So it is not easily possible let the programmer customize that color.
                 }
                 if ((!dateIsVetoed) && (highlightInfo != null)) {
                     // Get the "modifiable default" highlight and background colors from settings.
@@ -1020,7 +1020,7 @@ public class CalendarPanel extends JPanel {
      * date picker. This sets the date picker date to today.
      */
     private void labelSetDateToTodayMousePressed(MouseEvent e) {
-        userSelectedADate(LocalDate.now(settings.getClock()));
+        userSelectedADate(LocalDate.now(getClockForToday()));
     }
 
     /**
@@ -1039,7 +1039,7 @@ public class CalendarPanel extends JPanel {
         JPopupMenu yearPopupMenu = new JPopupMenu();
         for (int yearDifference = firstYearDifference; yearDifference <= lastYearDifference;
             ++yearDifference) {
-            // No special processing is required for the BC to AD transition in the 
+            // No special processing is required for the BC to AD transition in the
             // ISO 8601 calendar system. Year zero does exist in this system.
             // This try block handles exceptions that can occur at LocalDate.MAX.
             try {
@@ -1098,7 +1098,7 @@ public class CalendarPanel extends JPanel {
     public void setSelectedDate(LocalDate selectedDate) {
         setSelectedDateWithoutShowing(selectedDate);
         YearMonth yearMonthToShow
-            = (selectedDate == null) ? YearMonth.now(settings.getClock()) : YearMonth.from(selectedDate);
+            = (selectedDate == null) ? YearMonth.now(getClockForToday()) : YearMonth.from(selectedDate);
         setDisplayedYearMonth(yearMonthToShow);
     }
 
@@ -1685,7 +1685,7 @@ public class CalendarPanel extends JPanel {
         boolean showYearMenu = ((yearMenuSetting) && (!yearEditorPanelIsDisplayed));
         labelYear.setVisible(showYearMenu);
 
-        // Note: I had considered centering the today label in the CalendarPanel whenever the 
+        // Note: I had considered centering the today label in the CalendarPanel whenever the
         // clear label was hidden. However, it still looks better when it is aligned to the left.
         boolean showClearButton = (clearButtonSetting && emptyDatesAllowed);
         labelClearDate.setVisible(showClearButton);
@@ -1735,7 +1735,7 @@ public class CalendarPanel extends JPanel {
      */
     private Integer zGetWeekNumberForASevenDayRange(LocalDate firstDateInRange,
         WeekFields weekFieldRules, boolean requireUnanimousWeekNumber) {
-        // Get the week number for each of the seven days in the range. 
+        // Get the week number for each of the seven days in the range.
         ArrayList<Integer> weekNumbersList = new ArrayList<Integer>();
         for (int daysIntoTheFuture = 0; daysIntoTheFuture <= 6; ++daysIntoTheFuture) {
             LocalDate currentDateInRange;
@@ -1748,15 +1748,15 @@ public class CalendarPanel extends JPanel {
                 return 1;
             }
         }
-        // Find out if all the week numbers are the same. 
-        // We can check for a unanimous sequence by looking at the first and last number. 
+        // Find out if all the week numbers are the same.
+        // We can check for a unanimous sequence by looking at the first and last number.
         boolean isUnanimous = (InternalUtilities.areObjectsEqual(
             weekNumbersList.get(0), weekNumbersList.get(6)));
-        // If the week numbers are unanimous, then return the unanimous week number. 
+        // If the week numbers are unanimous, then return the unanimous week number.
         if (isUnanimous) {
             return weekNumbersList.get(0);
         }
-        // The week number is not unanimous. 
+        // The week number is not unanimous.
         // If unanimous week numbers are required, then return null.
         if (requireUnanimousWeekNumber) {
             return null;
@@ -1779,7 +1779,7 @@ public class CalendarPanel extends JPanel {
         }
         // Save the settings.
         this.settings = datePickerSettings;
-        // If this is an independent calendar panel, store the parent calendar panel in the 
+        // If this is an independent calendar panel, store the parent calendar panel in the
         // settings instance.
         if (isIndependentCalendarPanel) {
             settings.zSetParentCalendarPanel(this);
@@ -1791,7 +1791,7 @@ public class CalendarPanel extends JPanel {
         }
 
         // Apply the border properties settings.
-        // This is applied regardless of whether the calendar panel was created by a date picker, 
+        // This is applied regardless of whether the calendar panel was created by a date picker,
         // or as an independent calendar panel.
         zApplyBorderPropertiesList();
         // Set the label indicators to their default states.
@@ -1800,7 +1800,7 @@ public class CalendarPanel extends JPanel {
         // At the time of this writing, the "applied needed settings" included:
         // allow empty dates.
         if (isIndependentCalendarPanel) {
-            // Note: CalendarPanel.zApplyBorderPropertiesList() is called from the calendar panel 
+            // Note: CalendarPanel.zApplyBorderPropertiesList() is called from the calendar panel
             // constructor so it will be run both for independent and date picker calendar panels.
             settings.zApplyAllowEmptyDates();
         }
@@ -1824,5 +1824,13 @@ public class CalendarPanel extends JPanel {
 
     public JButton getNextYearButton() {
         return buttonNextYear;
+    }
+
+    private java.time.Clock getClockForToday()
+    {
+      if (settings != null) {
+        return settings.getClock();
+      }
+      return java.time.Clock.systemDefaultZone();
     }
 }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -179,8 +179,8 @@ public class TimePicker
         zAddKeyListenersToTextField();
 
         // Create a toggleTimeMenuButton listener for mouse dragging events.
-        // Note: The toggleTimeMenuButton listeners should be created here in the constructor, 
-        // because they do not require the timeMenuPanel to exist. These listeners are never 
+        // Note: The toggleTimeMenuButton listeners should be created here in the constructor,
+        // because they do not require the timeMenuPanel to exist. These listeners are never
         // deregistered. They will continue to exist for as long as the time picker exists.
         toggleTimeMenuButton.addMouseMotionListener(new MouseAdapter() {
             @Override
@@ -232,7 +232,7 @@ public class TimePicker
      * times, then the last valid time will not be changed by this function.
      */
     public void clear() {
-        // Calling this function with null clears the time picker text. 
+        // Calling this function with null clears the time picker text.
         // If empty times are allowed, this will also clear the last valid time.
         setTime(null);
     }
@@ -677,7 +677,7 @@ public class TimePicker
      * for additional details.
      */
     public void setTimeToNow() {
-        setTime(LocalTime.now());
+        setTime(LocalTime.now(settings.getClock()));
     }
 
     /**
@@ -749,7 +749,7 @@ public class TimePicker
                         timeMenuPanel.selectFirstEntry();
                     }
                 }
-                // Handled the up arrow key, which activates the spinner function to increase 
+                // Handled the up arrow key, which activates the spinner function to increase
                 // the time value.
                 if (enableArrowKeys && e.isActionKey() && e.getKeyCode() == KeyEvent.VK_UP) {
                     e.consume();
@@ -763,7 +763,7 @@ public class TimePicker
                     zInternalTryChangeTimeByIncrement(1);
                     increaseTimer.start();
                 }
-                // Handled the down arrow key, which activates the spinner function to decrease 
+                // Handled the down arrow key, which activates the spinner function to decrease
                 // the time value.
                 if (enableArrowKeys && e.isActionKey() && e.getKeyCode() == KeyEvent.VK_DOWN) {
                     e.consume();

--- a/Project/src/test/java/TestFeatures.java
+++ b/Project/src/test/java/TestFeatures.java
@@ -1,0 +1,154 @@
+/*
+ * The MIT License
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.github.lgooddatepicker.components.CalendarPanel;
+import com.github.lgooddatepicker.components.DatePicker;
+import com.github.lgooddatepicker.components.DatePickerSettings;
+import com.github.lgooddatepicker.components.TimePicker;
+import com.github.lgooddatepicker.components.TimePickerSettings;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+// add tests for your new features here
+public class TestFeatures
+{
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockDateSettings() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+      DatePickerSettings settings = new DatePickerSettings();
+      assertTrue("Default clock must be available", settings.getClock() != null);
+      assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+      settings = new DatePickerSettings(Locale.ENGLISH);
+      assertTrue("Default clock must be available", settings.getClock() != null);
+      assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+      Clock myClock = Clock.systemUTC();
+      settings.setClock(myClock);
+      assertTrue("Set clock must be returned", settings.getClock() == myClock);
+      settings.setClock(getClockFixedToInstant(1993, Month.MARCH, 15, 12, 00));
+      settings.setDefaultYearMonth(null);
+      YearMonth defaultyearmonth = (YearMonth)invokePrivateMethod(DatePickerSettings.class, settings, "zGetDefaultYearMonthAsUsed");
+      assertTrue(defaultyearmonth.getYear() == 1993);
+      assertTrue(defaultyearmonth.getMonth() == Month.MARCH);
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockTimeSettings() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException
+    {
+      TimePickerSettings settings = new TimePickerSettings();
+      assertTrue("Default clock must be available", settings.getClock() != null);
+      assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+      settings = new TimePickerSettings(Locale.ENGLISH);
+      assertTrue("Default clock must be available", settings.getClock() != null);
+      assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+      Clock myClock = Clock.systemUTC();
+      settings.setClock(myClock);
+      assertTrue("Set clock must be returned", settings.getClock() == myClock);
+      LocalTime initialTime = (LocalTime)readPrivateField(TimePickerSettings.class, settings, "initialTime");
+      assertTrue("intialtime is null as long as setInitialTimeToNow() has not been called", initialTime == null);
+      settings.setClock(getClockFixedToInstant(2000, Month.JANUARY, 1, 15,55));
+      settings.setInitialTimeToNow();
+      initialTime = (LocalTime)readPrivateField(TimePickerSettings.class, settings, "initialTime");
+      assertTrue("intialtime is not null after call to as long as setInitialTimeToNow()", initialTime != null);
+      assertTrue("intialtime must be 15:55 / 3:55pm", initialTime.equals(LocalTime.of(15, 55)));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockCalenderPanel()
+    {
+      CalendarPanel panel = new CalendarPanel();
+      java.time.YearMonth defaultDateNeverNull = panel.getDisplayedYearMonth();
+      assertTrue("displayedYearMonth may never be null", defaultDateNeverNull != null);
+      assertTrue("Year must be the year of today", defaultDateNeverNull.getYear() == LocalDate.now().getYear());
+      assertTrue("Month must be the month of today", defaultDateNeverNull.getMonthValue()== LocalDate.now().getMonthValue());
+
+      panel = new CalendarPanel(new DatePicker());
+      defaultDateNeverNull = panel.getDisplayedYearMonth();
+      assertTrue("displayedYearMonth may never be null", defaultDateNeverNull != null);
+      assertTrue("Year must be the year of today", defaultDateNeverNull.getYear() == LocalDate.now().getYear());
+      assertTrue("Month must be the month of today", defaultDateNeverNull.getMonthValue()== LocalDate.now().getMonthValue());
+
+      DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
+      settings.setClock(getClockFixedToInstant(1995, Month.OCTOBER, 31, 0, 0));
+      panel = new CalendarPanel(settings);
+      defaultDateNeverNull = panel.getDisplayedYearMonth();
+      assertTrue("displayedYearMonth may never be null", defaultDateNeverNull != null);
+      assertTrue("Year must be the year 1995", defaultDateNeverNull.getYear() == 1995);
+      assertTrue("Month must be the month October", defaultDateNeverNull.getMonth()== Month.OCTOBER);
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockDatePicker()
+    {
+      DatePicker picker = new DatePicker();
+      assertTrue(picker.getDate() == null);
+      DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
+      settings.setClock(getClockFixedToInstant(1995, Month.OCTOBER, 31, 14, 33));
+      picker = new DatePicker(settings);
+      picker.setDateToToday();
+      assertTrue("Picker must have set a date of 1995-10-31", picker.getDate().equals(LocalDate.of(1995, Month.OCTOBER, 31)));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockTimePicker()
+    {
+      TimePicker picker = new TimePicker();
+      assertTrue(picker.getTime() == null);
+      TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
+      settings.setClock(getClockFixedToInstant(1995, Month.OCTOBER, 31, 14, 33));
+      picker = new TimePicker(settings);
+      picker.setTimeToNow();
+      assertTrue("Picker must have set a time of 14:33 / 2:33pm", picker.getTime().equals(LocalTime.of(14, 33)));
+    }
+
+    // helper functions
+
+    Clock getClockFixedToInstant(int year, Month month, int day, int hours, int minutes)
+    {
+      LocalDateTime fixedInstant = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hours,minutes));
+      return Clock.fixed(fixedInstant.toInstant(ZoneOffset.UTC), ZoneId.of("Z"));
+    }
+
+    Object readPrivateField(Class<?> clazz, Object instance, String field) throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException
+    {
+        java.lang.reflect.Field private_field =  clazz.getDeclaredField(field);
+        private_field.setAccessible(true);
+        return private_field.get(instance);
+    }
+
+    Object invokePrivateMethod(Class<?> clazz, Object instance, String method, Object... args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        java.lang.reflect.Method private_method =  clazz.getDeclaredMethod(method);
+        private_method.setAccessible(true);
+        return private_method.invoke(instance, args);
+    }
+}

--- a/Project/src/test/java/TestRequirements.java
+++ b/Project/src/test/java/TestRequirements.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.github.lgooddatepicker.components.CalendarPanel;
+import com.github.lgooddatepicker.components.DatePicker;
+import com.github.lgooddatepicker.components.DatePickerSettings;
+import com.github.lgooddatepicker.components.TimePicker;
+import com.github.lgooddatepicker.components.TimePickerSettings;
+import java.util.Locale;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+// the tests in this class test basic requirements that always have to be fulfilled
+// these are not complete, feel free to extend them
+public class TestRequirements
+{
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void CalendarPanelConstructors()
+    {
+      CalendarPanel panel;
+      panel = new CalendarPanel();
+      assertTrue(panel.getDisplayedYearMonth() != null);
+      panel = new CalendarPanel(new DatePickerSettings());
+      assertTrue(panel.getDisplayedYearMonth() != null);
+      panel = new CalendarPanel(new DatePicker());
+      assertTrue(panel.getDisplayedYearMonth() != null);
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void DatePickerSettingsConstructors()
+    {
+      DatePickerSettings settings;
+      settings = new DatePickerSettings();
+      assertTrue(settings.getLocale().equals(Locale.getDefault()));
+      settings = new DatePickerSettings(Locale.ENGLISH);
+      assertTrue(settings.getLocale().equals(Locale.ENGLISH));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void DatePickerConstructors()
+    {
+      DatePicker picker;
+      picker = new DatePicker();
+      assertTrue(picker.getSettings().getLocale().equals(Locale.getDefault()));
+      picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
+      assertTrue(picker.getSettings().getLocale().equals(Locale.ENGLISH));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TimePickerSettingsConstructors()
+    {
+      TimePickerSettings settings;
+      settings = new TimePickerSettings();
+      assertTrue(settings.getLocale().equals(Locale.getDefault()));
+      settings = new TimePickerSettings(Locale.ENGLISH);
+      assertTrue(settings.getLocale().equals(Locale.ENGLISH));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TimePickerConstructors()
+    {
+      TimePicker picker;
+      picker = new TimePicker();
+      assertTrue(picker.getSettings().getLocale().equals(Locale.getDefault()));
+      picker = new TimePicker(new TimePickerSettings(Locale.ENGLISH));
+      assertTrue(picker.getSettings().getLocale().equals(Locale.ENGLISH));
+    }
+
+}


### PR DESCRIPTION
This *PR* provides:
* new tests for the feature added in *PR* #90 
* fixes two bugs encountered while writing these tests
  * Missing call to `settings.getClock()`
https://github.com/LGoodDatePicker/LGoodDatePicker/blob/73476fe38fe23facd3b088b5438ead370d14f37d/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java#L679-L681
  * One constructor of `CalenderPanel` threw an exception
https://github.com/LGoodDatePicker/LGoodDatePicker/blob/73476fe38fe23facd3b088b5438ead370d14f37d/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java#L210-L212
as the changed line below from *PR* #90 directly accessed `datePickerSettings` even if it was `null`
https://github.com/LGoodDatePicker/LGoodDatePicker/blob/73476fe38fe23facd3b088b5438ead370d14f37d/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java#L253
* increases the version to `v11.0.1` due to the bug fixes