### PR TITLE
Add more coverage to TimePicker tests.

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -19,7 +19,7 @@ plugins in this file operate inside the "package" and "install" phases.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lgooddatepicker</groupId>
     <artifactId>LGoodDatePicker</artifactId>
-    <version>11.0.1</version>
+    <version>11.0.2</version>
     <packaging>jar</packaging>
     <name>LGoodDatePicker</name>
     <description>Java Swing Date Picker. Easy to use, good looking, nice features, and

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -994,7 +994,7 @@ public class TimePicker
      */
     private void zInternalSetTimeTextField(String text) {
         skipTextFieldChangedFunctionWhileTrue = true;
-        if (settings.useLowercaseForDisplayTime) {
+        if (settings.useLowercaseForDisplayTime && text != null) {
             text = text.toLowerCase(settings.getLocale());
         }
         timeTextField.setText(text);

--- a/Project/src/test/java/TestFeatures.java
+++ b/Project/src/test/java/TestFeatures.java
@@ -21,13 +21,7 @@
  * THE SOFTWARE.
  */
 
-import com.github.lgooddatepicker.components.CalendarPanel;
-import com.github.lgooddatepicker.components.DatePicker;
-import com.github.lgooddatepicker.components.DatePickerSettings;
-import com.github.lgooddatepicker.components.TimePicker;
-import com.github.lgooddatepicker.components.TimePickerSettings;
-import com.github.lgooddatepicker.optionalusertools.TimeChangeListener;
-import com.github.lgooddatepicker.zinternaltools.TimeChangeEvent;
+import static org.junit.Assert.assertTrue;
 
 import java.awt.Color;
 import java.awt.event.MouseEvent;
@@ -40,11 +34,17 @@ import java.time.Month;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.util.Locale;
+
 import javax.swing.JLabel;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import com.github.lgooddatepicker.components.CalendarPanel;
+import com.github.lgooddatepicker.components.DatePicker;
+import com.github.lgooddatepicker.components.DatePickerSettings;
+import com.github.lgooddatepicker.components.TimePicker;
+import com.github.lgooddatepicker.components.TimePickerSettings;
 
 // add tests for your new features here
 public class TestFeatures
@@ -184,111 +184,7 @@ public class TestFeatures
         assertTrue(labelname+" has wrong text color: "+labeltoverify.getForeground().toString(), labeltoverify.getForeground().equals(defaultText));
     }
 
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void verifyTimePicker()
-    {
-        TimePicker picker = new TimePicker();
-        picker.setTime(LocalTime.MIN);
-        assertEquals("minium local time could not be used", LocalTime.MIN, picker.getTime());
-        picker.setTime(LocalTime.NOON);
-        assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
-        picker.setTime(LocalTime.MAX);
-        assertEquals("maximum local time could not be used", LocalTime.MAX.truncatedTo(ChronoUnit.MINUTES), picker.getTime());
-        picker.setTime(null);
-        assertNull("null time could not be used", picker.getTime());
-        picker.setEnableArrowKeys(true);
-        assertTrue("Arrow keys not enabled", picker.getEnableArrowKeys());
-        picker.setEnableArrowKeys(false);
-        assertFalse("Arrow keys not disabled", picker.getEnableArrowKeys());
-        
-        assertNotNull("Picker settings were null", picker.getSettings());       
-        
-        picker.setEnabled(false);
-        assertFalse("Picker was not disabled", picker.isEnabled());
-        assertFalse("Menu component was not disabled", picker.getComponentToggleTimeMenuButton().isEnabled());
-        assertFalse("TextField component was not disabled", picker.getComponentTimeTextField().isEnabled());
-        
-        picker.setEnabled(true);
-        assertTrue("Picker was not disabled", picker.isEnabled());
-        assertTrue("Menu component was not enabled", picker.getComponentToggleTimeMenuButton().isEnabled());
-        assertTrue("TextField component was not enabled", picker.getComponentTimeTextField().isEnabled());
-        
-        picker.setTime(LocalTime.NOON);
-        assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
-        picker.clear();
-        assertNull("Clear did not make the time null", picker.getTime());
-        
-        // valid text
-        picker.setText("12:22");
-        assertTrue("Expected time to be valid", picker.isTextValid("12:22"));
-        assertTrue("Expected field to be valid", picker.isTextFieldValid());
-        assertEquals("Did not retain user text", "12:22", picker.getText());
-        assertEquals("Entered time not translated to local time", LocalTime.of(12, 22), picker.getTime());
-        assertEquals("Expected time string for valid time", "12:22", picker.getTimeStringOrSuppliedString("supply"));
-        
-        // invalid text
-        picker.setText("44:17");
-        assertFalse("Expected time to be invalid", picker.isTextValid("44:17"));
-        assertFalse("Expected timefield  to be invalid", picker.isTextFieldValid());
-        assertEquals("Did not retain user text", "44:17", picker.getText());
-        // because time is invalid the old local time should still be present
-        assertEquals("Invalid time was translated to local time", LocalTime.of(12, 22), picker.getTime());
-        
-        // null time
-        picker.setTime(null);
-        assertEquals("Expected empty string for null time", "", picker.getTimeStringOrEmptyString());
-        assertEquals("Expected supplied string for null time", "supply", picker.getTimeStringOrSuppliedString("supply"));
-        
-        // null text
-        assertFalse("null text was considered valid", picker.isTextValid(null));
-        picker.setText(null);
-        assertEquals("null text did not become blank text", "", picker.getText());
-        
-        // empty text
-        assertTrue("spaces only text was considered valid", picker.isTextValid("  "));
-        picker.setText("  ");
-        assertEquals("spaces text was not returned", "  ", picker.getText());
-        
-        // toString
-        picker.setTime(LocalTime.of(8, 32));
-        assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
-        picker.setTime(LocalTime.of(8, 32, 12));
-        assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
-        
-        assertTrue("Expect noon to be an allowed time", picker.isTimeAllowed(LocalTime.NOON));
-        
-    }
-
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void verifyTimeChangeListeners()
-    {
-        TimePicker picker = new TimePicker();
-        TestableTimeChangeListener listener = new TestableTimeChangeListener();
-        picker.addTimeChangeListener(listener);
-        assertNull("listener event not null at start", listener.getLastEvent());
-        picker.setTime(LocalTime.MIN);
-        assertEquals("Listener did not receive new time", LocalTime.MIN, listener.getLastEvent().getNewTime());
-        assertNull("Listener did not remember old time", listener.getLastEvent().getOldTime());
-        assertEquals("Event did not originate from time picker", picker, listener.getLastEvent().getSource());
-
-        TimeChangeEvent lastEvent = listener.getLastEvent();
-        picker.setTime(LocalTime.MIN);
-        assertTrue("Event updated when time did not change", lastEvent == listener.getLastEvent());
-
-        picker.setTime(LocalTime.NOON);
-        assertEquals("Listener did not remember old time", LocalTime.MIN, listener.getLastEvent().getOldTime());
-        assertEquals("Listener did not receive new time", LocalTime.NOON, listener.getLastEvent().getNewTime());
-
-        picker.setTime(null);
-        assertNull("Listener did not receive null time", listener.getLastEvent().getNewTime());
-        
-        assertTrue("Listener was not in the list of listeners", picker.getTimeChangeListeners().contains(listener));
-        
-        picker.removeTimeChangeListener(listener);
-        picker.setTime(LocalTime.NOON);
-        assertNull("Listener received an update after being uninstalled", listener.getLastEvent().getNewTime());
-        
-    }
+   
 
     // helper functions
     Clock getClockFixedToInstant(int year, Month month, int day, int hours, int minutes)
@@ -311,18 +207,5 @@ public class TestFeatures
         return private_method;
     }
 
-    //helper class
-    private class TestableTimeChangeListener implements TimeChangeListener
-    {
-        TimeChangeEvent lastEvent;
-
-        @Override
-        public void timeChanged(TimeChangeEvent event) {
-            lastEvent = event;
-        }
-
-        TimeChangeEvent getLastEvent() {
-            return lastEvent;
-        }
-    }
+   
 }

--- a/Project/src/test/java/TestFeatures.java
+++ b/Project/src/test/java/TestFeatures.java
@@ -200,6 +200,63 @@ public class TestFeatures
         assertTrue("Arrow keys not enabled", picker.getEnableArrowKeys());
         picker.setEnableArrowKeys(false);
         assertFalse("Arrow keys not disabled", picker.getEnableArrowKeys());
+        
+        assertNotNull("Picker settings were null", picker.getSettings());       
+        
+        picker.setEnabled(false);
+        assertFalse("Picker was not disabled", picker.isEnabled());
+        assertFalse("Menu component was not disabled", picker.getComponentToggleTimeMenuButton().isEnabled());
+        assertFalse("TextField component was not disabled", picker.getComponentTimeTextField().isEnabled());
+        
+        picker.setEnabled(true);
+        assertTrue("Picker was not disabled", picker.isEnabled());
+        assertTrue("Menu component was not enabled", picker.getComponentToggleTimeMenuButton().isEnabled());
+        assertTrue("TextField component was not enabled", picker.getComponentTimeTextField().isEnabled());
+        
+        picker.setTime(LocalTime.NOON);
+        assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
+        picker.clear();
+        assertNull("Clear did not make the time null", picker.getTime());
+        
+        // valid text
+        picker.setText("12:22");
+        assertTrue("Expected time to be valid", picker.isTextValid("12:22"));
+        assertTrue("Expected field to be valid", picker.isTextFieldValid());
+        assertEquals("Did not retain user text", "12:22", picker.getText());
+        assertEquals("Entered time not translated to local time", LocalTime.of(12, 22), picker.getTime());
+        assertEquals("Expected time string for valid time", "12:22", picker.getTimeStringOrSuppliedString("supply"));
+        
+        // invalid text
+        picker.setText("44:17");
+        assertFalse("Expected time to be invalid", picker.isTextValid("44:17"));
+        assertFalse("Expected timefield  to be invalid", picker.isTextFieldValid());
+        assertEquals("Did not retain user text", "44:17", picker.getText());
+        // because time is invalid the old local time should still be present
+        assertEquals("Invalid time was translated to local time", LocalTime.of(12, 22), picker.getTime());
+        
+        // null time
+        picker.setTime(null);
+        assertEquals("Expected empty string for null time", "", picker.getTimeStringOrEmptyString());
+        assertEquals("Expected supplied string for null time", "supply", picker.getTimeStringOrSuppliedString("supply"));
+        
+        // null text
+        assertFalse("null text was considered valid", picker.isTextValid(null));
+        picker.setText(null);
+        assertEquals("null text did not become blank text", "", picker.getText());
+        
+        // empty text
+        assertTrue("spaces only text was considered valid", picker.isTextValid("  "));
+        picker.setText("  ");
+        assertEquals("spaces text was not returned", "  ", picker.getText());
+        
+        // toString
+        picker.setTime(LocalTime.of(8, 32));
+        assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
+        picker.setTime(LocalTime.of(8, 32, 12));
+        assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
+        
+        assertTrue("Expect noon to be an allowed time", picker.isTimeAllowed(LocalTime.NOON));
+        
     }
 
     @Test( expected = Test.None.class /* no exception expected */ )
@@ -224,6 +281,13 @@ public class TestFeatures
 
         picker.setTime(null);
         assertNull("Listener did not receive null time", listener.getLastEvent().getNewTime());
+        
+        assertTrue("Listener was not in the list of listeners", picker.getTimeChangeListeners().contains(listener));
+        
+        picker.removeTimeChangeListener(listener);
+        picker.setTime(LocalTime.NOON);
+        assertNull("Listener received an update after being uninstalled", listener.getLastEvent().getNewTime());
+        
     }
 
     // helper functions

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
@@ -1,0 +1,205 @@
+/*
+ * The MIT License
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.github.lgooddatepicker.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+import org.junit.Test;
+
+import com.github.lgooddatepicker.optionalusertools.TimeChangeListener;
+import com.github.lgooddatepicker.zinternaltools.TimeChangeEvent;
+
+/**
+ * Tests for the TimePicker component features
+ */
+public class TestTimePicker {
+	
+	/**
+	 * Basic test of the time picker functions
+	 */
+	@Test(expected = Test.None.class /* no exception expected */ )
+	public void verifyTimePickerBasics() 
+	{
+		TimePicker picker = new TimePicker();
+		
+		// Test the range of Local times
+		picker.setTime(LocalTime.MIN);
+		assertEquals("minium local time could not be used", LocalTime.MIN, picker.getTime());
+		picker.setTime(LocalTime.NOON);
+		assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
+		picker.setTime(LocalTime.MAX);
+		assertEquals("maximum local time could not be used", LocalTime.MAX.truncatedTo(ChronoUnit.MINUTES),
+				picker.getTime());
+		
+		// test clearing the component by setting the time to null
+		picker.setTime(null);
+		assertNull("null time could not be used", picker.getTime());
+		
+		// reset the the picker back to noon
+		picker.setTime(LocalTime.NOON);
+		// ensure it can be set again after set to null
+		assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
+		
+		// clear it again
+		picker.clear();
+		// ensure that clear also sets time to null
+		assertNull("Clear did not make the time null", picker.getTime());
+		
+	}
+	
+	/**
+	 * Tests that the various parts of the TimePicker can be enabled
+	 * and disabled as expected
+	 */
+	@Test(expected = Test.None.class /* no exception expected */ )
+	public void verifyTimePickerEnabled() 
+	{
+		TimePicker picker = new TimePicker();
+		picker.setEnableArrowKeys(true);
+		assertTrue("Arrow keys not enabled", picker.getEnableArrowKeys());
+		picker.setEnableArrowKeys(false);
+		assertFalse("Arrow keys not disabled", picker.getEnableArrowKeys());
+
+		assertNotNull("Picker settings were null", picker.getSettings());
+
+		picker.setEnabled(false);
+		assertFalse("Picker was not disabled", picker.isEnabled());
+		assertFalse("Menu component was not disabled", picker.getComponentToggleTimeMenuButton().isEnabled());
+		assertFalse("TextField component was not disabled", picker.getComponentTimeTextField().isEnabled());
+
+		picker.setEnabled(true);
+		assertTrue("Picker was not disabled", picker.isEnabled());
+		assertTrue("Menu component was not enabled", picker.getComponentToggleTimeMenuButton().isEnabled());
+		assertTrue("TextField component was not enabled", picker.getComponentTimeTextField().isEnabled());
+	}
+		
+	/**
+	 * Test to ensure that the parsing and strings work as expected.
+	 * Here Locale.ENGLISH is specified to ensure the test is 
+	 * consistent when run on systems in other Locales.
+	 */
+	@Test(expected = Test.None.class /* no exception expected */ )
+	public void verifyTimePickerParsingAndStrings() 
+	{
+		TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
+		TimePicker picker = new TimePicker(settings);
+		// valid text
+		picker.setText("12:22");
+		assertTrue("Expected time to be valid", picker.isTextValid("12:22"));
+		assertTrue("Expected field to be valid", picker.isTextFieldValid());
+		assertEquals("Did not retain user text", "12:22", picker.getText());
+		assertEquals("Entered time not translated to local time", LocalTime.of(12, 22), picker.getTime());
+		assertEquals("Expected time string for valid time", "12:22", picker.getTimeStringOrSuppliedString("supply"));
+
+		// invalid text
+		picker.setText("44:17");
+		assertFalse("Expected time to be invalid", picker.isTextValid("44:17"));
+		assertFalse("Expected timefield  to be invalid", picker.isTextFieldValid());
+		assertEquals("Did not retain user text", "44:17", picker.getText());
+		// because time is invalid the old local time should still be present
+		assertEquals("Invalid time was translated to local time", LocalTime.of(12, 22), picker.getTime());
+
+		// null time
+		picker.setTime(null);
+		assertEquals("Expected empty string for null time", "", picker.getTimeStringOrEmptyString());
+		assertEquals("Expected supplied string for null time", "supply",
+				picker.getTimeStringOrSuppliedString("supply"));
+
+		// null text
+		assertFalse("null text was considered valid", picker.isTextValid(null));
+		picker.setText(null);
+		assertEquals("null text did not become blank text", "", picker.getText());
+
+		// empty text
+		assertTrue("spaces only text was considered valid", picker.isTextValid("  "));
+		picker.setText("  ");
+		assertEquals("spaces text was not returned", "  ", picker.getText());
+
+		// toString
+		picker.setTime(LocalTime.of(8, 32));
+		assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
+		picker.setTime(LocalTime.of(8, 32, 12));
+		assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
+
+		assertTrue("Expect noon to be an allowed time", picker.isTimeAllowed(LocalTime.NOON));
+
+	}
+
+	/**
+	 * Tests to ensure that the TimeChangeListener works
+	 * as expected.
+	 */
+	@Test(expected = Test.None.class /* no exception expected */ )
+	public void verifyTimeChangeListeners() 
+	{
+		TimePicker picker = new TimePicker();
+		TestableTimeChangeListener listener = new TestableTimeChangeListener();
+		picker.addTimeChangeListener(listener);
+		assertNull("listener event not null at start", listener.getLastEvent());
+		picker.setTime(LocalTime.MIN);
+		assertEquals("Listener did not receive new time", LocalTime.MIN, listener.getLastEvent().getNewTime());
+		assertNull("Listener did not remember old time", listener.getLastEvent().getOldTime());
+		assertEquals("Event did not originate from time picker", picker, listener.getLastEvent().getSource());
+
+		TimeChangeEvent lastEvent = listener.getLastEvent();
+		picker.setTime(LocalTime.MIN);
+		assertTrue("Event updated when time did not change", lastEvent == listener.getLastEvent());
+
+		picker.setTime(LocalTime.NOON);
+		assertEquals("Listener did not remember old time", LocalTime.MIN, listener.getLastEvent().getOldTime());
+		assertEquals("Listener did not receive new time", LocalTime.NOON, listener.getLastEvent().getNewTime());
+
+		picker.setTime(null);
+		assertNull("Listener did not receive null time", listener.getLastEvent().getNewTime());
+		
+		assertTrue("Listener was not in the list of listeners", picker.getTimeChangeListeners().contains(listener));
+
+		picker.removeTimeChangeListener(listener);
+		picker.setTime(LocalTime.NOON);
+		assertNull("Listener received an update after being uninstalled", listener.getLastEvent().getNewTime());
+
+	}
+
+	// helper class
+	private class TestableTimeChangeListener implements TimeChangeListener 
+	{
+		TimeChangeEvent lastEvent;
+
+		@Override
+		public void timeChanged(TimeChangeEvent event) {
+			lastEvent = event;
+		}
+
+		TimeChangeEvent getLastEvent() {
+			return lastEvent;
+		}
+	}
+}

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
@@ -41,15 +41,15 @@ import com.github.lgooddatepicker.zinternaltools.TimeChangeEvent;
  * Tests for the TimePicker component features
  */
 public class TestTimePicker {
-    
+
     /**
      * Basic test of the time picker functions
      */
     @Test(expected = Test.None.class /* no exception expected */ )
-    public void verifyTimePickerBasics() 
+    public void verifyTimePickerBasics()
     {
         TimePicker picker = new TimePicker();
-        
+
         // Test the range of Local times
         picker.setTime(LocalTime.MIN);
         assertEquals("minium local time could not be used", LocalTime.MIN, picker.getTime());
@@ -58,29 +58,29 @@ public class TestTimePicker {
         picker.setTime(LocalTime.MAX);
         assertEquals("maximum local time could not be used", LocalTime.MAX.truncatedTo(ChronoUnit.MINUTES),
                 picker.getTime());
-        
+
         // test clearing the component by setting the time to null
         picker.setTime(null);
         assertNull("null time could not be used", picker.getTime());
-        
+
         // reset the the picker back to noon
         picker.setTime(LocalTime.NOON);
         // ensure it can be set again after set to null
         assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
-        
+
         // clear it again
         picker.clear();
         // ensure that clear also sets time to null
         assertNull("Clear did not make the time null", picker.getTime());
-        
+
     }
-    
+
     /**
      * Tests that the various parts of the TimePicker can be enabled
      * and disabled as expected
      */
     @Test(expected = Test.None.class /* no exception expected */ )
-    public void verifyTimePickerEnabled() 
+    public void verifyTimePickerEnabled()
     {
         TimePicker picker = new TimePicker();
         picker.setEnableArrowKeys(true);
@@ -100,16 +100,17 @@ public class TestTimePicker {
         assertTrue("Menu component was not enabled", picker.getComponentToggleTimeMenuButton().isEnabled());
         assertTrue("TextField component was not enabled", picker.getComponentTimeTextField().isEnabled());
     }
-        
+
     /**
      * Test to ensure that the parsing and strings work as expected.
-     * Here Locale.ENGLISH is specified to ensure the test is 
+     * Here Locale.ENGLISH is specified to ensure the test is
      * consistent when run on systems in other Locales.
      */
     @Test(expected = Test.None.class /* no exception expected */ )
-    public void verifyTimePickerParsingAndStrings() 
+    public void verifyTimePickerParsingAndStrings()
     {
         TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
+        settings.useLowercaseForDisplayTime = true;
         TimePicker picker = new TimePicker(settings);
         // valid text
         picker.setText("12:22");
@@ -158,7 +159,7 @@ public class TestTimePicker {
      * as expected.
      */
     @Test(expected = Test.None.class /* no exception expected */ )
-    public void verifyTimeChangeListeners() 
+    public void verifyTimeChangeListeners()
     {
         TimePicker picker = new TimePicker();
         TestableTimeChangeListener listener = new TestableTimeChangeListener();
@@ -179,7 +180,7 @@ public class TestTimePicker {
 
         picker.setTime(null);
         assertNull("Listener did not receive null time", listener.getLastEvent().getNewTime());
-        
+
         assertTrue("Listener was not in the list of listeners", picker.getTimeChangeListeners().contains(listener));
 
         picker.removeTimeChangeListener(listener);
@@ -189,7 +190,7 @@ public class TestTimePicker {
     }
 
     // helper class
-    private class TestableTimeChangeListener implements TimeChangeListener 
+    private class TestableTimeChangeListener implements TimeChangeListener
     {
         TimeChangeEvent lastEvent;
 

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
@@ -41,165 +41,165 @@ import com.github.lgooddatepicker.zinternaltools.TimeChangeEvent;
  * Tests for the TimePicker component features
  */
 public class TestTimePicker {
-	
-	/**
-	 * Basic test of the time picker functions
-	 */
-	@Test(expected = Test.None.class /* no exception expected */ )
-	public void verifyTimePickerBasics() 
-	{
-		TimePicker picker = new TimePicker();
-		
-		// Test the range of Local times
-		picker.setTime(LocalTime.MIN);
-		assertEquals("minium local time could not be used", LocalTime.MIN, picker.getTime());
-		picker.setTime(LocalTime.NOON);
-		assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
-		picker.setTime(LocalTime.MAX);
-		assertEquals("maximum local time could not be used", LocalTime.MAX.truncatedTo(ChronoUnit.MINUTES),
-				picker.getTime());
-		
-		// test clearing the component by setting the time to null
-		picker.setTime(null);
-		assertNull("null time could not be used", picker.getTime());
-		
-		// reset the the picker back to noon
-		picker.setTime(LocalTime.NOON);
-		// ensure it can be set again after set to null
-		assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
-		
-		// clear it again
-		picker.clear();
-		// ensure that clear also sets time to null
-		assertNull("Clear did not make the time null", picker.getTime());
-		
-	}
-	
-	/**
-	 * Tests that the various parts of the TimePicker can be enabled
-	 * and disabled as expected
-	 */
-	@Test(expected = Test.None.class /* no exception expected */ )
-	public void verifyTimePickerEnabled() 
-	{
-		TimePicker picker = new TimePicker();
-		picker.setEnableArrowKeys(true);
-		assertTrue("Arrow keys not enabled", picker.getEnableArrowKeys());
-		picker.setEnableArrowKeys(false);
-		assertFalse("Arrow keys not disabled", picker.getEnableArrowKeys());
+    
+    /**
+     * Basic test of the time picker functions
+     */
+    @Test(expected = Test.None.class /* no exception expected */ )
+    public void verifyTimePickerBasics() 
+    {
+        TimePicker picker = new TimePicker();
+        
+        // Test the range of Local times
+        picker.setTime(LocalTime.MIN);
+        assertEquals("minium local time could not be used", LocalTime.MIN, picker.getTime());
+        picker.setTime(LocalTime.NOON);
+        assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
+        picker.setTime(LocalTime.MAX);
+        assertEquals("maximum local time could not be used", LocalTime.MAX.truncatedTo(ChronoUnit.MINUTES),
+                picker.getTime());
+        
+        // test clearing the component by setting the time to null
+        picker.setTime(null);
+        assertNull("null time could not be used", picker.getTime());
+        
+        // reset the the picker back to noon
+        picker.setTime(LocalTime.NOON);
+        // ensure it can be set again after set to null
+        assertEquals("noon local time could not be used", LocalTime.NOON, picker.getTime());
+        
+        // clear it again
+        picker.clear();
+        // ensure that clear also sets time to null
+        assertNull("Clear did not make the time null", picker.getTime());
+        
+    }
+    
+    /**
+     * Tests that the various parts of the TimePicker can be enabled
+     * and disabled as expected
+     */
+    @Test(expected = Test.None.class /* no exception expected */ )
+    public void verifyTimePickerEnabled() 
+    {
+        TimePicker picker = new TimePicker();
+        picker.setEnableArrowKeys(true);
+        assertTrue("Arrow keys not enabled", picker.getEnableArrowKeys());
+        picker.setEnableArrowKeys(false);
+        assertFalse("Arrow keys not disabled", picker.getEnableArrowKeys());
 
-		assertNotNull("Picker settings were null", picker.getSettings());
+        assertNotNull("Picker settings were null", picker.getSettings());
 
-		picker.setEnabled(false);
-		assertFalse("Picker was not disabled", picker.isEnabled());
-		assertFalse("Menu component was not disabled", picker.getComponentToggleTimeMenuButton().isEnabled());
-		assertFalse("TextField component was not disabled", picker.getComponentTimeTextField().isEnabled());
+        picker.setEnabled(false);
+        assertFalse("Picker was not disabled", picker.isEnabled());
+        assertFalse("Menu component was not disabled", picker.getComponentToggleTimeMenuButton().isEnabled());
+        assertFalse("TextField component was not disabled", picker.getComponentTimeTextField().isEnabled());
 
-		picker.setEnabled(true);
-		assertTrue("Picker was not disabled", picker.isEnabled());
-		assertTrue("Menu component was not enabled", picker.getComponentToggleTimeMenuButton().isEnabled());
-		assertTrue("TextField component was not enabled", picker.getComponentTimeTextField().isEnabled());
-	}
-		
-	/**
-	 * Test to ensure that the parsing and strings work as expected.
-	 * Here Locale.ENGLISH is specified to ensure the test is 
-	 * consistent when run on systems in other Locales.
-	 */
-	@Test(expected = Test.None.class /* no exception expected */ )
-	public void verifyTimePickerParsingAndStrings() 
-	{
-		TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
-		TimePicker picker = new TimePicker(settings);
-		// valid text
-		picker.setText("12:22");
-		assertTrue("Expected time to be valid", picker.isTextValid("12:22"));
-		assertTrue("Expected field to be valid", picker.isTextFieldValid());
-		assertEquals("Did not retain user text", "12:22", picker.getText());
-		assertEquals("Entered time not translated to local time", LocalTime.of(12, 22), picker.getTime());
-		assertEquals("Expected time string for valid time", "12:22", picker.getTimeStringOrSuppliedString("supply"));
+        picker.setEnabled(true);
+        assertTrue("Picker was not disabled", picker.isEnabled());
+        assertTrue("Menu component was not enabled", picker.getComponentToggleTimeMenuButton().isEnabled());
+        assertTrue("TextField component was not enabled", picker.getComponentTimeTextField().isEnabled());
+    }
+        
+    /**
+     * Test to ensure that the parsing and strings work as expected.
+     * Here Locale.ENGLISH is specified to ensure the test is 
+     * consistent when run on systems in other Locales.
+     */
+    @Test(expected = Test.None.class /* no exception expected */ )
+    public void verifyTimePickerParsingAndStrings() 
+    {
+        TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
+        TimePicker picker = new TimePicker(settings);
+        // valid text
+        picker.setText("12:22");
+        assertTrue("Expected time to be valid", picker.isTextValid("12:22"));
+        assertTrue("Expected field to be valid", picker.isTextFieldValid());
+        assertEquals("Did not retain user text", "12:22", picker.getText());
+        assertEquals("Entered time not translated to local time", LocalTime.of(12, 22), picker.getTime());
+        assertEquals("Expected time string for valid time", "12:22", picker.getTimeStringOrSuppliedString("supply"));
 
-		// invalid text
-		picker.setText("44:17");
-		assertFalse("Expected time to be invalid", picker.isTextValid("44:17"));
-		assertFalse("Expected timefield  to be invalid", picker.isTextFieldValid());
-		assertEquals("Did not retain user text", "44:17", picker.getText());
-		// because time is invalid the old local time should still be present
-		assertEquals("Invalid time was translated to local time", LocalTime.of(12, 22), picker.getTime());
+        // invalid text
+        picker.setText("44:17");
+        assertFalse("Expected time to be invalid", picker.isTextValid("44:17"));
+        assertFalse("Expected timefield  to be invalid", picker.isTextFieldValid());
+        assertEquals("Did not retain user text", "44:17", picker.getText());
+        // because time is invalid the old local time should still be present
+        assertEquals("Invalid time was translated to local time", LocalTime.of(12, 22), picker.getTime());
 
-		// null time
-		picker.setTime(null);
-		assertEquals("Expected empty string for null time", "", picker.getTimeStringOrEmptyString());
-		assertEquals("Expected supplied string for null time", "supply",
-				picker.getTimeStringOrSuppliedString("supply"));
+        // null time
+        picker.setTime(null);
+        assertEquals("Expected empty string for null time", "", picker.getTimeStringOrEmptyString());
+        assertEquals("Expected supplied string for null time", "supply",
+                picker.getTimeStringOrSuppliedString("supply"));
 
-		// null text
-		assertFalse("null text was considered valid", picker.isTextValid(null));
-		picker.setText(null);
-		assertEquals("null text did not become blank text", "", picker.getText());
+        // null text
+        assertFalse("null text was considered valid", picker.isTextValid(null));
+        picker.setText(null);
+        assertEquals("null text did not become blank text", "", picker.getText());
 
-		// empty text
-		assertTrue("spaces only text was considered valid", picker.isTextValid("  "));
-		picker.setText("  ");
-		assertEquals("spaces text was not returned", "  ", picker.getText());
+        // empty text
+        assertTrue("spaces only text was considered valid", picker.isTextValid("  "));
+        picker.setText("  ");
+        assertEquals("spaces text was not returned", "  ", picker.getText());
 
-		// toString
-		picker.setTime(LocalTime.of(8, 32));
-		assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
-		picker.setTime(LocalTime.of(8, 32, 12));
-		assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
+        // toString
+        picker.setTime(LocalTime.of(8, 32));
+        assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
+        picker.setTime(LocalTime.of(8, 32, 12));
+        assertEquals("toString should match toTime", picker.getTimeStringOrEmptyString(), picker.toString());
 
-		assertTrue("Expect noon to be an allowed time", picker.isTimeAllowed(LocalTime.NOON));
+        assertTrue("Expect noon to be an allowed time", picker.isTimeAllowed(LocalTime.NOON));
 
-	}
+    }
 
-	/**
-	 * Tests to ensure that the TimeChangeListener works
-	 * as expected.
-	 */
-	@Test(expected = Test.None.class /* no exception expected */ )
-	public void verifyTimeChangeListeners() 
-	{
-		TimePicker picker = new TimePicker();
-		TestableTimeChangeListener listener = new TestableTimeChangeListener();
-		picker.addTimeChangeListener(listener);
-		assertNull("listener event not null at start", listener.getLastEvent());
-		picker.setTime(LocalTime.MIN);
-		assertEquals("Listener did not receive new time", LocalTime.MIN, listener.getLastEvent().getNewTime());
-		assertNull("Listener did not remember old time", listener.getLastEvent().getOldTime());
-		assertEquals("Event did not originate from time picker", picker, listener.getLastEvent().getSource());
+    /**
+     * Tests to ensure that the TimeChangeListener works
+     * as expected.
+     */
+    @Test(expected = Test.None.class /* no exception expected */ )
+    public void verifyTimeChangeListeners() 
+    {
+        TimePicker picker = new TimePicker();
+        TestableTimeChangeListener listener = new TestableTimeChangeListener();
+        picker.addTimeChangeListener(listener);
+        assertNull("listener event not null at start", listener.getLastEvent());
+        picker.setTime(LocalTime.MIN);
+        assertEquals("Listener did not receive new time", LocalTime.MIN, listener.getLastEvent().getNewTime());
+        assertNull("Listener did not remember old time", listener.getLastEvent().getOldTime());
+        assertEquals("Event did not originate from time picker", picker, listener.getLastEvent().getSource());
 
-		TimeChangeEvent lastEvent = listener.getLastEvent();
-		picker.setTime(LocalTime.MIN);
-		assertTrue("Event updated when time did not change", lastEvent == listener.getLastEvent());
+        TimeChangeEvent lastEvent = listener.getLastEvent();
+        picker.setTime(LocalTime.MIN);
+        assertTrue("Event updated when time did not change", lastEvent == listener.getLastEvent());
 
-		picker.setTime(LocalTime.NOON);
-		assertEquals("Listener did not remember old time", LocalTime.MIN, listener.getLastEvent().getOldTime());
-		assertEquals("Listener did not receive new time", LocalTime.NOON, listener.getLastEvent().getNewTime());
+        picker.setTime(LocalTime.NOON);
+        assertEquals("Listener did not remember old time", LocalTime.MIN, listener.getLastEvent().getOldTime());
+        assertEquals("Listener did not receive new time", LocalTime.NOON, listener.getLastEvent().getNewTime());
 
-		picker.setTime(null);
-		assertNull("Listener did not receive null time", listener.getLastEvent().getNewTime());
-		
-		assertTrue("Listener was not in the list of listeners", picker.getTimeChangeListeners().contains(listener));
+        picker.setTime(null);
+        assertNull("Listener did not receive null time", listener.getLastEvent().getNewTime());
+        
+        assertTrue("Listener was not in the list of listeners", picker.getTimeChangeListeners().contains(listener));
 
-		picker.removeTimeChangeListener(listener);
-		picker.setTime(LocalTime.NOON);
-		assertNull("Listener received an update after being uninstalled", listener.getLastEvent().getNewTime());
+        picker.removeTimeChangeListener(listener);
+        picker.setTime(LocalTime.NOON);
+        assertNull("Listener received an update after being uninstalled", listener.getLastEvent().getNewTime());
 
-	}
+    }
 
-	// helper class
-	private class TestableTimeChangeListener implements TimeChangeListener 
-	{
-		TimeChangeEvent lastEvent;
+    // helper class
+    private class TestableTimeChangeListener implements TimeChangeListener 
+    {
+        TimeChangeEvent lastEvent;
 
-		@Override
-		public void timeChanged(TimeChangeEvent event) {
-			lastEvent = event;
-		}
+        @Override
+        public void timeChanged(TimeChangeEvent event) {
+            lastEvent = event;
+        }
 
-		TimeChangeEvent getLastEvent() {
-			return lastEvent;
-		}
-	}
+        TimeChangeEvent getLastEvent() {
+            return lastEvent;
+        }
+    }
 }


### PR DESCRIPTION
Also, prevent a NPE if setText(null) is used.  Null is accepted by normal
JTextFields, and it's not mentioned in the TimePicker documentation one way or the
other.