### PR TITLE
Extend Java CI to build with JDK 8 and JDK 11

### DIFF
--- a/.github/workflows/mavenbuildandtest.yml
+++ b/.github/workflows/mavenbuildandtest.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Java CI build & test
 
 on:
   push:
@@ -10,15 +10,29 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  buildAndTestJava8:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Set up Git repository
+      uses: actions/checkout@v2
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Build with Maven
+    - name: Build and test with Maven
+      run: mvn -B package --file Project/pom.xml
+
+
+  buildAndTestJava11:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Git repository
+      uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build and test with Maven
       run: mvn -B package --file Project/pom.xml

--- a/.github/workflows/mavenpublishcentral.yml
+++ b/.github/workflows/mavenpublishcentral.yml
@@ -11,18 +11,16 @@ on:
   #    - releases
 
 jobs:
-  release:
+  publishRelease:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Git repository
+      - name: Set up Git repository
         uses: actions/checkout@v2
-
-      - name: Install Java and Maven
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
-      - name: Release Maven package
+      - name: Build package and publish to Maven Central Repository
         uses: samuelmeuli/action-maven-publish@v1.4.0
         with:
           gpg_private_key: ${{ secrets.MVN_GPG_SIGN_SECRET_KEY }}


### PR DESCRIPTION
This *PR* provides:
* extension of Java *CI* to build with JDK 11 additionally to JDK 1.8
* better names for *CI* jobs and *CI* steps