### PR TITLE
Make the DatePicker panel transparent

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -151,6 +151,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
      */
     public DatePicker(DatePickerSettings settings) {
         initComponents();
+        setOpaque(false);
         this.convert = new Convert(this);
         // Shrink the toggle calendar button to a reasonable size.
         toggleCalendarButton.setMargin(new java.awt.Insets(1, 2, 1, 2));


### PR DESCRIPTION
I'm using the date picker on a background that is not the default color of a JPanel, in this situation the gap between the text field and the toggle button appears with a different color:

![image](https://user-images.githubusercontent.com/54304/95333946-bab94300-08ad-11eb-9cf7-a1f7a12bef25.png)

I suggest making the DatePicker panel transparent to avoid this issue.