### PR TITLE
Customizable date/time text field colors when in disabled state 

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -973,8 +973,8 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             // (Possibility: DisabledComponent)
             // Note: The date should always be validated (as if the component lost focus), before
             // the component is disabled.
-            dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisabledDate));
-            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextDisabledDate));
+            dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisabled));
+            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextDisabled));
 
             dateTextField.setFont(settings.getFontValidDate());
             return;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -975,7 +975,6 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             // the component is disabled.
             dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisabled));
             dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextDisabled));
-
             dateTextField.setFont(settings.getFontValidDate());
             return;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -974,7 +974,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             // Note: The date should always be validated (as if the component lost focus), before
             // the component is disabled.
             dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisabledDate));
-            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextValidDate));
+            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextDisabledDate));
 
             dateTextField.setFont(settings.getFontValidDate());
             return;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -181,6 +181,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
         settings.zApplyGapBeforeButtonPixels();
         settings.zApplyAllowKeyboardEditing();
         settings.zApplyAllowEmptyDates();
+        settings.zApplyDisabledTextColor();
         // Draw the text field indicators, because they may not have been drawn if the initialDate
         // was null. (This is because the text would not have changed in that case.)
         // This should be called after the DatePickerSettings have been saved.
@@ -974,7 +975,6 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             // Note: The date should always be validated (as if the component lost focus), before
             // the component is disabled.
             dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisabled));
-            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextDisabled));
             dateTextField.setFont(settings.getFontValidDate());
             return;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -973,8 +973,9 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
             // (Possibility: DisabledComponent)
             // Note: The date should always be validated (as if the component lost focus), before
             // the component is disabled.
-            dateTextField.setBackground(new Color(240, 240, 240));
-            dateTextField.setForeground(new Color(109, 109, 109));
+            dateTextField.setBackground(settings.getColor(DateArea.TextFieldBackgroundDisabledDate));
+            dateTextField.setForeground(settings.getColor(DateArea.DatePickerTextValidDate));
+
             dateTextField.setFont(settings.getFontValidDate());
             return;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -1347,6 +1347,11 @@ public class DatePickerSettings {
                     parentCalendarPanel.zSetAllLabelIndicatorColorsToDefaultState();
                 }
                 break;
+            case DatePickerTextDisabled:
+                if (parentDatePicker != null) {
+                    zApplyDisabledTextColor();
+                }
+                break;
             default:
                 if (parentDatePicker != null) {
                     parentDatePicker.zDrawTextFieldIndicators();
@@ -2249,6 +2254,12 @@ public class DatePickerSettings {
         if (parentCalendarPanel != null) {
             parentCalendarPanel.zApplyVisibilityOfButtons();
         }
+    }
+
+    void zApplyDisabledTextColor()
+    {
+        parentDatePicker.getComponentDateTextField().setDisabledTextColor(
+                getColor(DateArea.DatePickerTextDisabled));
     }
 
     /**

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -89,11 +89,11 @@ public class DatePickerSettings {
         TextFieldBackgroundInvalidDate(Color.white),
         TextFieldBackgroundValidDate(Color.white),
         TextFieldBackgroundVetoedDate(Color.white),
-        TextFieldBackgroundDisabledDate(new Color(240, 240, 240)),
+        TextFieldBackgroundDisabled(new Color(240, 240, 240)),
         DatePickerTextInvalidDate(Color.red),
         DatePickerTextValidDate(Color.black),
         DatePickerTextVetoedDate(Color.black),
-        DatePickerTextDisabledDate(new Color(109, 109, 109));
+        DatePickerTextDisabled(new Color(109, 109, 109));
 
         DateArea(Color defaultColor) {
             this.defaultColor = defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -93,7 +93,7 @@ public class DatePickerSettings {
         DatePickerTextInvalidDate(Color.red),
         DatePickerTextValidDate(Color.black),
         DatePickerTextVetoedDate(Color.black),
-        DatePickerTextDisabledTime(new Color(109, 109, 109));
+        DatePickerTextDisabledDate(new Color(109, 109, 109));
 
         DateArea(Color defaultColor) {
             this.defaultColor = defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -89,9 +89,11 @@ public class DatePickerSettings {
         TextFieldBackgroundInvalidDate(Color.white),
         TextFieldBackgroundValidDate(Color.white),
         TextFieldBackgroundVetoedDate(Color.white),
+        TextFieldBackgroundDisabledDate(new Color(240, 240, 240)),
         DatePickerTextInvalidDate(Color.red),
         DatePickerTextValidDate(Color.black),
-        DatePickerTextVetoedDate(Color.black);
+        DatePickerTextVetoedDate(Color.black),
+        DatePickerTextDisabledTime(new Color(109, 109, 109));
 
         DateArea(Color defaultColor) {
             this.defaultColor = defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -847,7 +847,6 @@ public class TimePicker
             // Note: The time should always be validated (as if the component lost focus), before
             // the component is disabled.
             timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundDisabled));
-            timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextDisabled));
             timeTextField.setFont(settings.fontValidTime);
             return;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -846,8 +846,8 @@ public class TimePicker
             // (Possibility: DisabledComponent)
             // Note: The time should always be validated (as if the component lost focus), before
             // the component is disabled.
-            timeTextField.setBackground(new Color(240, 240, 240));
-            timeTextField.setForeground(new Color(109, 109, 109));
+            timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundDisabledTime));
+            timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextDisabledTime));
             timeTextField.setFont(settings.fontValidTime);
             return;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -846,8 +846,8 @@ public class TimePicker
             // (Possibility: DisabledComponent)
             // Note: The time should always be validated (as if the component lost focus), before
             // the component is disabled.
-            timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundDisabledTime));
-            timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextDisabledTime));
+            timeTextField.setBackground(settings.getColor(TimeArea.TextFieldBackgroundDisabled));
+            timeTextField.setForeground(settings.getColor(TimeArea.TimePickerTextDisabled));
             timeTextField.setFont(settings.fontValidTime);
             return;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -634,7 +634,12 @@ public class TimePickerSettings {
 
         // Call any "updating functions" that are appropriate for the specified area.
         if (parent != null) {
-            parent.zDrawTextFieldIndicators();
+            if (area == TimeArea.TimePickerTextDisabled)
+            {
+                zApplyDisabledTextColor();
+            } else {
+                parent.zDrawTextFieldIndicators();
+            }
         }
     }
 

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -61,12 +61,12 @@ public class TimePickerSettings {
         TimePickerTextValidTime(Color.black),
         TimePickerTextInvalidTime(Color.red),
         TimePickerTextVetoedTime(Color.black),
-        TimePickerTextDisabledTime(new Color(109, 109, 109)),
+        TimePickerTextDisabled(new Color(109, 109, 109)),
         TextFieldBackgroundValidTime(Color.white),
         TextFieldBackgroundInvalidTime(Color.white),
         TextFieldBackgroundVetoedTime(Color.white),
         TextFieldBackgroundDisallowedEmptyTime(Color.pink),
-        TextFieldBackgroundDisabledTime(new Color(240, 240, 240));
+        TextFieldBackgroundDisabled(new Color(240, 240, 240));
 
         TimeArea(Color defaultColor) {
             this.defaultColor = defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -61,10 +61,12 @@ public class TimePickerSettings {
         TimePickerTextValidTime(Color.black),
         TimePickerTextInvalidTime(Color.red),
         TimePickerTextVetoedTime(Color.black),
+        TimePickerTextDisabledTime(new Color(109, 109, 109)),
         TextFieldBackgroundValidTime(Color.white),
         TextFieldBackgroundInvalidTime(Color.white),
         TextFieldBackgroundVetoedTime(Color.white),
-        TextFieldBackgroundDisallowedEmptyTime(Color.pink);
+        TextFieldBackgroundDisallowedEmptyTime(Color.pink),
+        TextFieldBackgroundDisabledTime(new Color(240, 240, 240));
 
         TimeArea(Color defaultColor) {
             this.defaultColor = defaultColor;

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -873,6 +873,7 @@ public class TimePickerSettings {
         zApplyMinimumSpinnerButtonWidthInPixels();
         zApplyDisplayToggleTimeMenuButton();
         zApplyDisplaySpinnerButtons();
+        zApplyDisabledTextColor();
     }
 
     /**
@@ -1013,6 +1014,12 @@ public class TimePickerSettings {
         width = (width < minimumWidth) ? minimumWidth : width;
         Dimension newSize = new Dimension(width, height);
         parent.getComponentToggleTimeMenuButton().setPreferredSize(newSize);
+    }
+
+    void zApplyDisabledTextColor()
+    {
+        parent.getComponentTimeTextField().setDisabledTextColor(getColor(
+                TimeArea.TimePickerTextDisabled));
     }
 
     /**

--- a/Project/src/test/java/TestFeatures.java
+++ b/Project/src/test/java/TestFeatures.java
@@ -43,8 +43,10 @@ import org.junit.Test;
 import com.github.lgooddatepicker.components.CalendarPanel;
 import com.github.lgooddatepicker.components.DatePicker;
 import com.github.lgooddatepicker.components.DatePickerSettings;
+import com.github.lgooddatepicker.components.DatePickerSettings.DateArea;
 import com.github.lgooddatepicker.components.TimePicker;
 import com.github.lgooddatepicker.components.TimePickerSettings;
+import static org.junit.Assert.assertFalse;
 
 // add tests for your new features here
 public class TestFeatures
@@ -164,7 +166,7 @@ public class TestFeatures
                 clearLabelText);
     }
 
-        @Test( expected = Test.None.class /* no exception expected */ )
+    @Test( expected = Test.None.class /* no exception expected */ )
     public void TestCustomMouseHoverColorCalendarPanel() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException
     {
         DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
@@ -210,7 +212,57 @@ public class TestFeatures
         assertTrue(labelname+" has wrong text color: "+labeltoverify.getForeground().toString(), labeltoverify.getForeground().equals(defaultText));
     }
 
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomDisabledPickerColor()
+    {
+        final Color defaultDisabledText =  new DatePickerSettings().getColor(
+                DateArea.DatePickerTextDisabled);
+        final Color defaultDisabledBackground = new DatePickerSettings().getColor(
+                DateArea.TextFieldBackgroundDisabled);
 
+        DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
+        settings.setColor(DateArea.DatePickerTextDisabled, Color.yellow);
+        settings.setColor(DateArea.TextFieldBackgroundDisabled, Color.blue);
+
+        DatePicker picker = new DatePicker(settings);
+
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+        picker.setEnabled(false);
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+
+        picker.setSettings(new DatePickerSettings(Locale.ENGLISH));
+        validateDatePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
+
+        picker.getSettings().setColor(DateArea.DatePickerTextDisabled, Color.yellow);
+        validateDatePickerDisabledColor(picker, Color.yellow, defaultDisabledBackground);
+        picker.getSettings().setColor(DateArea.TextFieldBackgroundDisabled, Color.blue);
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+        picker.setEnabled(true);
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+
+        picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
+        validateDatePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
+    }
+
+    void validateDatePickerDisabledColor(DatePicker picker, Color disabledTextColor, Color disabledBackground)
+    {
+        final Color validText = new DatePickerSettings().getColor(
+                DatePickerSettings.DateArea.DatePickerTextValidDate);
+        final Color enabledBackground = new DatePickerSettings().getColor(
+                DateArea.TextFieldBackgroundValidDate);
+
+        assertTrue(picker.getComponentDateTextField().getForeground().equals(validText));
+        assertFalse(picker.getComponentDateTextField().getForeground().equals(disabledTextColor));
+        assertTrue(picker.getComponentDateTextField().getDisabledTextColor().equals(disabledTextColor));
+        assertFalse(picker.getComponentDateTextField().getDisabledTextColor().equals(validText));
+        if (picker.isEnabled()) {
+            assertTrue(picker.getComponentDateTextField().getBackground().equals(enabledBackground));
+            assertFalse(picker.getComponentDateTextField().getBackground().equals(disabledBackground));
+        } else {
+            assertTrue(picker.getComponentDateTextField().getBackground().equals(disabledBackground));
+            assertFalse(picker.getComponentDateTextField().getBackground().equals(enabledBackground));
+        }
+    }
 
     // helper functions
     Clock getClockFixedToInstant(int year, Month month, int day, int hours, int minutes)

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
@@ -22,6 +22,7 @@
  */
 package com.github.lgooddatepicker.components;
 
+import com.github.lgooddatepicker.components.TimePickerSettings.TimeArea;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -36,6 +37,7 @@ import org.junit.Test;
 
 import com.github.lgooddatepicker.optionalusertools.TimeChangeListener;
 import com.github.lgooddatepicker.zinternaltools.TimeChangeEvent;
+import java.awt.Color;
 
 /**
  * Tests for the TimePicker component features
@@ -187,6 +189,60 @@ public class TestTimePicker {
         picker.setTime(LocalTime.NOON);
         assertNull("Listener received an update after being uninstalled", listener.getLastEvent().getNewTime());
 
+    }
+
+    /**
+     * Test to ensure that the custom colors for the disabled time picker work as excepcted
+     */
+    @Test(expected = Test.None.class /* no exception expected */ )
+    public void verifyCustomDisabledColors()
+    {
+        final Color defaultDisabledText =  new TimePickerSettings().getColor(
+                TimeArea.TimePickerTextDisabled);
+        final Color defaultDisabledBackground = new TimePickerSettings().getColor(
+                TimeArea.TextFieldBackgroundDisabled);
+
+        TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
+        settings.setColor(TimeArea.TimePickerTextDisabled, Color.yellow);
+        settings.setColor(TimeArea.TextFieldBackgroundDisabled, Color.blue);
+
+        TimePicker picker = new TimePicker(settings);
+
+        validateTimePickerDisabledColor(picker, Color.yellow, Color.blue);
+        picker.setEnabled(false);
+        validateTimePickerDisabledColor(picker, Color.yellow, Color.blue);
+
+        picker = new TimePicker(new TimePickerSettings(Locale.ENGLISH));
+        validateTimePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
+        picker.setEnabled(false);
+        validateTimePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
+
+        picker.getSettings().setColor(TimeArea.TimePickerTextDisabled, Color.yellow);
+        validateTimePickerDisabledColor(picker, Color.yellow, defaultDisabledBackground);
+        picker.getSettings().setColor(TimeArea.TextFieldBackgroundDisabled, Color.blue);
+        validateTimePickerDisabledColor(picker, Color.yellow, Color.blue);
+        picker.setEnabled(true);
+        validateTimePickerDisabledColor(picker, Color.yellow, Color.blue);
+    }
+
+    void validateTimePickerDisabledColor(TimePicker picker, Color disabledTextColor, Color disabledBackground)
+    {
+        final Color validText = new TimePickerSettings().getColor(
+                TimeArea.TimePickerTextValidTime);
+        final Color enabledBackground = new TimePickerSettings().getColor(
+                TimeArea.TextFieldBackgroundValidTime);
+
+        assertTrue(picker.getComponentTimeTextField().getForeground().equals(validText));
+        assertFalse(picker.getComponentTimeTextField().getForeground().equals(disabledTextColor));
+        assertTrue(picker.getComponentTimeTextField().getDisabledTextColor().equals(disabledTextColor));
+        assertFalse(picker.getComponentTimeTextField().getDisabledTextColor().equals(validText));
+        if (picker.isEnabled()) {
+            assertTrue(picker.getComponentTimeTextField().getBackground().equals(enabledBackground));
+            assertFalse(picker.getComponentTimeTextField().getBackground().equals(disabledBackground));
+        } else {
+            assertTrue(picker.getComponentTimeTextField().getBackground().equals(disabledBackground));
+            assertFalse(picker.getComponentTimeTextField().getBackground().equals(enabledBackground));
+        }
     }
 
     // helper class


### PR DESCRIPTION
Move disabled state background and foreground colors to TimeArea and DateArea so that they can be customized. Current values are retained as the default values for these new settings.