### PR TITLE
Run tests on Windows in addition to Linux

### DIFF
--- a/.github/workflows/mavenbuildandtest.yml
+++ b/.github/workflows/mavenbuildandtest.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  buildAndTestJava8:
+  buildAndTestJava8-linux:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,8 +24,36 @@ jobs:
       run: mvn -B package --file Project/pom.xml
 
 
-  buildAndTestJava11:
+  buildAndTestJava11-linux:
     runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Git repository
+      uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build and test with Maven
+      run: mvn -B package --file Project/pom.xml
+
+
+  buildAndTestJava8-windows:
+    runs-on: windows-latest
+
+    steps:
+    - name: Set up Git repository
+      uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build and test with Maven
+      run: mvn -B package --file Project/pom.xml
+
+
+  buildAndTestJava11-windows:
+    runs-on: windows-latest
 
     steps:
     - name: Set up Git repository

--- a/Project/src/test/java/TestGithubIssues.java
+++ b/Project/src/test/java/TestGithubIssues.java
@@ -85,7 +85,7 @@ public class TestGithubIssues {
             assertFalse("DatePicker must not have an open popup.", date_picker.isPopupOpen());
             Thread.sleep(10);
             date_picker.openPopup();
-            Thread.sleep(10);
+            Thread.sleep(30);
             assertTrue("DatePicker must have an open popup.", date_picker.isPopupOpen());
             testWin.dispatchEvent(new WindowEvent(testWin, WindowEvent.WINDOW_CLOSING));
             Thread.sleep(50);


### PR DESCRIPTION
This *PR* provides
------------------
* __Test execution on Windows:__
Windows runners allow the execution of tests which require full UI support to run. These tests are skipped on Linux runners as they only support a *headless* JDK
* a small *delay* increase to stabilize an UI test on Windows