### PR TITLE
Cleanup test packages

### DIFF
--- a/Project/src/test/java/com/github/lgooddatepicker/TestFeatures.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestFeatures.java
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.github.lgooddatepicker;
 
 import static org.junit.Assert.assertTrue;
 

--- a/Project/src/test/java/com/github/lgooddatepicker/TestGithubIssues.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestGithubIssues.java
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.github.lgooddatepicker;
 
 import com.github.lgooddatepicker.components.CalendarPanel;
 import com.github.lgooddatepicker.components.DatePicker;

--- a/Project/src/test/java/com/github/lgooddatepicker/TestGithubIssues.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestGithubIssues.java
@@ -22,10 +22,10 @@
  */
 package com.github.lgooddatepicker;
 
+import com.github.lgooddatepicker.TestHelpers.ExceptionInfo;
 import com.github.lgooddatepicker.components.CalendarPanel;
 import com.github.lgooddatepicker.components.DatePicker;
 import com.github.lgooddatepicker.components.DatePickerSettings;
-import com.github.lgooddatepicker.zinternaltools.Pair;
 import java.awt.AWTException;
 import java.awt.Color;
 import java.awt.event.InputEvent;
@@ -40,28 +40,18 @@ import javax.swing.JPopupMenu;
 import javax.swing.WindowConstants;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.Before;
 
 public class TestGithubIssues {
-    DatePicker date_picker;
-
-    @Before
-    public void setUp()
-    {
-        date_picker = new DatePicker();
-        date_picker.getSettings().setLocale(Locale.ENGLISH);
-        date_picker.getSettings().getFormatsForParsing().clear();
-    }
 
     @Test( expected = Test.None.class /* no exception expected */ )
     public void TestIssue82() throws InterruptedException
     {
-      if (!isUiAvailable())
+      if (!TestHelpers.isUiAvailable())
       {
         // don't run under CI
         System.out.println("TestIssue82 requires UI to run and was skipped");
       }
-      org.junit.Assume.assumeTrue(isUiAvailable());
+      org.junit.Assume.assumeTrue(TestHelpers.isUiAvailable());
 
         // The exception that might be thrown by the date picker control
         // will be thrown in an AWT-EventQueue thread. To be able to detect
@@ -71,13 +61,14 @@ public class TestGithubIssues {
         // from any running thread
         final ExceptionInfo exInfo = new ExceptionInfo();
         try {
-            RegisterUncaughtExceptionHandlerToAllThreads(new Thread.UncaughtExceptionHandler() {
+            TestHelpers.registerUncaughtExceptionHandlerToAllThreads(new Thread.UncaughtExceptionHandler() {
                 @Override
                 public void uncaughtException( Thread t, Throwable e ) {
                     exInfo.set(t.getName(), e);
                 }
             });
             JFrame testWin = new JFrame();
+            DatePicker date_picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
             testWin.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
             testWin.add(date_picker);
             testWin.pack();
@@ -96,7 +87,7 @@ public class TestGithubIssues {
                     +"\nStacktrace:\n"+exInfo.getStackTrace()
                     , exInfo.wasSet());
             } finally {
-                RegisterUncaughtExceptionHandlerToAllThreads(null);
+            TestHelpers.registerUncaughtExceptionHandlerToAllThreads(null);
         }
     }
 
@@ -108,7 +99,7 @@ public class TestGithubIssues {
         dateSettingsPgmDate.getFormatsForParsing().clear();
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy").withLocale(Locale.ENGLISH);
         dateSettingsPgmDate.setFormatForDatesCommonEra(dateFormatter);
-        date_picker.setSettings(dateSettingsPgmDate);
+        DatePicker date_picker = new DatePicker(dateSettingsPgmDate);
         date_picker.getComponentDateTextField().setEditable(false);
         date_picker.getComponentDateTextField().setToolTipText("The earliest date for booking to display.");
         date_picker.getComponentToggleCalendarButton().setToolTipText("The earliest date for booking to display.");
@@ -119,44 +110,48 @@ public class TestGithubIssues {
         date_picker.getComponentDateTextField().setDisabledTextColor(Color.BLACK);
         date_picker.setBounds(115, 50, 160, 20);
         date_picker.setDateToToday();
-        AssertDateTextValidity("sun, 11 Aug 2019", false);
-        AssertDateTextValidity("Sun, 11 Aug 2019", true);
-        AssertDateTextValidity("Mon, 11 Aug 2019", false);
-        AssertDateTextValidity("Tue, 30 Apr 2019", true);
-        AssertDateTextValidity("Wed, 31 Apr 2019", false);
+        AssertDateTextValidity(date_picker, "sun, 11 Aug 2019", false);
+        AssertDateTextValidity(date_picker, "Sun, 11 Aug 2019", true);
+        AssertDateTextValidity(date_picker, "Mon, 11 Aug 2019", false);
+        AssertDateTextValidity(date_picker, "Tue, 30 Apr 2019", true);
+        AssertDateTextValidity(date_picker, "Wed, 31 Apr 2019", false);
     }
 
     @Test( expected = Test.None.class /* no exception expected */ )
     public void TestIssue74()
     {
         DateTimeFormatter era_date = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DatePicker date_picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
+        date_picker.getSettings().getFormatsForParsing().clear();
         date_picker.getSettings().setFormatForDatesCommonEra(era_date);
-        AssertDateTextValidity("12/31/2019", false);
-        AssertDateTextValidity("31/12/2019", true);
-        AssertDateTextValidity("31/04/2019", false);
-        AssertDateTextValidity("30/04/2019", true);
+        AssertDateTextValidity(date_picker, "12/31/2019", false);
+        AssertDateTextValidity(date_picker, "31/12/2019", true);
+        AssertDateTextValidity(date_picker, "31/04/2019", false);
+        AssertDateTextValidity(date_picker, "30/04/2019", true);
     }
 
     @Test( expected = Test.None.class /* no exception expected */ )
     public void TestIssue60()
     {
         DateTimeFormatter era_date = DateTimeFormatter.ofPattern("ddMMyyyy");
+        DatePicker date_picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
+        date_picker.getSettings().getFormatsForParsing().clear();
         date_picker.getSettings().setFormatForDatesCommonEra(era_date);
-        AssertDateTextValidity("30 04 2019", false);
-        AssertDateTextValidity("30042019", true);
-        AssertDateTextValidity("31042019", false);
-        AssertDateTextValidity(" 30042019 ", true);
+        AssertDateTextValidity(date_picker, "30 04 2019", false);
+        AssertDateTextValidity(date_picker, "30042019", true);
+        AssertDateTextValidity(date_picker, "31042019", false);
+        AssertDateTextValidity(date_picker, " 30042019 ", true);
     }
 
     @Test( expected = Test.None.class /* no exception expected */ )
     public void TestIssue110() throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException, AWTException
     {
-        if (!isUiAvailable())
+        if (!TestHelpers.isUiAvailable())
         {
           // don't run under CI
           System.out.println("TestIssue110 requires UI to run and was skipped");
         }
-        org.junit.Assume.assumeTrue(isUiAvailable());
+        org.junit.Assume.assumeTrue(TestHelpers.isUiAvailable());
 
 
         DatePickerSettings dateSettings = new DatePickerSettings(Locale.ENGLISH);
@@ -252,7 +247,7 @@ public class TestGithubIssues {
 
     // helper functions
 
-    private void AssertDateTextValidity(String dateString, boolean isDateTexValid)
+    private void AssertDateTextValidity(DatePicker date_picker, String dateString, boolean isDateTexValid)
     {
         final boolean dateValid = date_picker.isTextValid(dateString);
         if (isDateTexValid) {
@@ -282,59 +277,6 @@ public class TestGithubIssues {
         else {
             assertTrue("False positive! Text should have invalid color: "+date_picker.getText(), textfieldcolor == invalidDate);
             assertTrue("False positive! Text should not have valid color: "+date_picker.getText(), textfieldcolor != validDate);
-        }
-    }
-
-    // detect funcionality of UI, which is not available on most CI systems
-    boolean isUiAvailable()
-    {
-      return !java.awt.GraphicsEnvironment.isHeadless();
-    }
-
-    static private void RegisterUncaughtExceptionHandlerToAllThreads(Thread.UncaughtExceptionHandler handler)
-    {
-        Thread.setDefaultUncaughtExceptionHandler(handler);
-        //activeCount is only an estimation
-        int activeCountOversize = 1;
-        Thread[] threads;
-        do {
-          threads = new Thread[Thread.activeCount() + activeCountOversize];
-          Thread.enumerate(threads);
-          activeCountOversize++;
-        } while (threads[threads.length-1] != null);
-        for (Thread thread : threads) {
-          if (thread != null) {
-              thread.setUncaughtExceptionHandler(handler);
-          }
-        }
-    }
-
-    private class ExceptionInfo
-    {
-        Pair<String, Throwable> info = new Pair<>("", null);
-
-        synchronized boolean wasSet() {
-            return !info.first.isEmpty() || info.second != null;
-        }
-        synchronized void set(String threadname, Throwable ex) {
-            info.first = threadname;
-            info.second = ex;
-        }
-        synchronized String getThreadName() {
-            return info.first;
-        }
-        synchronized String getExceptionMessage() {
-            return info.second != null ? info.second.getMessage() : "";
-        }
-        synchronized String getStackTrace()
-        {
-            String result = "";
-            if (info.second != null) {
-                for (StackTraceElement elem : info.second.getStackTrace()) {
-                    result += elem.toString()+"\n";
-                }
-            }
-            return result;
         }
     }
 

--- a/Project/src/test/java/com/github/lgooddatepicker/TestHelpers.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestHelpers.java
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.github.lgooddatepicker;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -36,7 +37,7 @@ public class TestHelpers
         return true;
     }
 
-    static Object readPrivateField(Class<?> clazz, Object instance, String field)
+    public static Object readPrivateField(Class<?> clazz, Object instance, String field)
             throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException
     {
         java.lang.reflect.Field private_field = clazz.getDeclaredField(field);
@@ -44,7 +45,7 @@ public class TestHelpers
         return private_field.get(instance);
     }
 
-    static java.lang.reflect.Method accessPrivateMethod(Class<?> clazz, String method, Class<?>... argclasses)
+    public static java.lang.reflect.Method accessPrivateMethod(Class<?> clazz, String method, Class<?>... argclasses)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
         java.lang.reflect.Method private_method = clazz.getDeclaredMethod(method, argclasses);

--- a/Project/src/test/java/com/github/lgooddatepicker/TestRequirements.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestRequirements.java
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.github.lgooddatepicker;
 
 import com.github.lgooddatepicker.components.CalendarPanel;
 import com.github.lgooddatepicker.components.DatePicker;

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestCalendarPanel.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestCalendarPanel.java
@@ -20,78 +20,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.github.lgooddatepicker;
+package com.github.lgooddatepicker.components;
 
-import static org.junit.Assert.assertTrue;
-
+import com.github.lgooddatepicker.TestHelpers;
 import java.awt.Color;
 import java.awt.event.MouseEvent;
 import java.lang.reflect.InvocationTargetException;
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.Month;
-import java.time.YearMonth;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Locale;
-
 import javax.swing.JLabel;
-
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
-import com.github.lgooddatepicker.components.CalendarPanel;
-import com.github.lgooddatepicker.components.DatePicker;
-import com.github.lgooddatepicker.components.DatePickerSettings;
-import com.github.lgooddatepicker.components.DatePickerSettings.DateArea;
-import com.github.lgooddatepicker.components.TimePicker;
-import com.github.lgooddatepicker.components.TimePickerSettings;
-import static org.junit.Assert.assertFalse;
-
-// add tests for your new features here
-public class TestFeatures
+public class TestCalendarPanel
 {
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void TestCustomClockDateSettings() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
-    {
-        DatePickerSettings settings = new DatePickerSettings();
-        assertTrue("Default clock must be available", settings.getClock() != null);
-        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
-        settings = new DatePickerSettings(Locale.ENGLISH);
-        assertTrue("Default clock must be available", settings.getClock() != null);
-        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
-        Clock myClock = Clock.systemUTC();
-        settings.setClock(myClock);
-        assertTrue("Set clock must be returned", settings.getClock() == myClock);
-        settings.setClock(getClockFixedToInstant(1993, Month.MARCH, 15, 12, 00));
-        settings.setDefaultYearMonth(null);
-        YearMonth defaultyearmonth = (YearMonth) TestHelpers.accessPrivateMethod(DatePickerSettings.class, "zGetDefaultYearMonthAsUsed").invoke(settings);
-        assertTrue(defaultyearmonth.getYear() == 1993);
-        assertTrue(defaultyearmonth.getMonth() == Month.MARCH);
-    }
-
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void TestCustomClockTimeSettings() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException
-    {
-        TimePickerSettings settings = new TimePickerSettings();
-        assertTrue("Default clock must be available", settings.getClock() != null);
-        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
-        settings = new TimePickerSettings(Locale.ENGLISH);
-        assertTrue("Default clock must be available", settings.getClock() != null);
-        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
-        Clock myClock = Clock.systemUTC();
-        settings.setClock(myClock);
-        assertTrue("Set clock must be returned", settings.getClock() == myClock);
-        LocalTime initialTime = (LocalTime) TestHelpers.readPrivateField(TimePickerSettings.class, settings, "initialTime");
-        assertTrue("intialtime is null as long as setInitialTimeToNow() has not been called", initialTime == null);
-        settings.setClock(getClockFixedToInstant(2000, Month.JANUARY, 1, 15,55));
-        settings.setInitialTimeToNow();
-        initialTime = (LocalTime) TestHelpers.readPrivateField(TimePickerSettings.class, settings, "initialTime");
-        assertTrue("intialtime is not null after call to as long as setInitialTimeToNow()", initialTime != null);
-        assertTrue("intialtime must be 15:55 / 3:55pm", initialTime.equals(LocalTime.of(15, 55)));
-    }
-
     @Test( expected = Test.None.class /* no exception expected */ )
     public void TestCustomClockCalenderPanel()
     {
@@ -108,36 +51,12 @@ public class TestFeatures
         assertTrue("Month must be the month of today", defaultDateNeverNull.getMonthValue()== LocalDate.now().getMonthValue());
 
         DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
-        settings.setClock(getClockFixedToInstant(1995, Month.OCTOBER, 31, 0, 0));
+        settings.setClock(TestHelpers.getClockFixedToInstant(1995, Month.OCTOBER, 31, 0, 0));
         panel = new CalendarPanel(settings);
         defaultDateNeverNull = panel.getDisplayedYearMonth();
         assertTrue("displayedYearMonth may never be null", defaultDateNeverNull != null);
         assertTrue("Year must be the year 1995", defaultDateNeverNull.getYear() == 1995);
         assertTrue("Month must be the month October", defaultDateNeverNull.getMonth()== Month.OCTOBER);
-    }
-
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void TestCustomClockDatePicker()
-    {
-        DatePicker picker = new DatePicker();
-        assertTrue(picker.getDate() == null);
-        DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
-        settings.setClock(getClockFixedToInstant(1995, Month.OCTOBER, 31, 14, 33));
-        picker = new DatePicker(settings);
-        picker.setDateToToday();
-        assertTrue("Picker must have set a date of 1995-10-31", picker.getDate().equals(LocalDate.of(1995, Month.OCTOBER, 31)));
-    }
-
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void TestCustomClockTimePicker()
-    {
-        TimePicker picker = new TimePicker();
-        assertTrue(picker.getTime() == null);
-        TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
-        settings.setClock(getClockFixedToInstant(1995, Month.OCTOBER, 31, 14, 33));
-        picker = new TimePicker(settings);
-        picker.setTimeToNow();
-        assertTrue("Picker must have set a time of 14:33 / 2:33pm", picker.getTime().equals(LocalTime.of(14, 33)));
     }
 
     @Test( expected = Test.None.class /* no exception expected */ )
@@ -210,65 +129,6 @@ public class TestFeatures
         TestHelpers.accessPrivateMethod(java.awt.Component.class, "processEvent", java.awt.AWTEvent.class).invoke(labeltoverify, testEvent);
         assertTrue(labelname+" has wrong background color: "+labeltoverify.getBackground().toString(), labeltoverify.getBackground().equals(defaultBackground));
         assertTrue(labelname+" has wrong text color: "+labeltoverify.getForeground().toString(), labeltoverify.getForeground().equals(defaultText));
-    }
-
-    @Test( expected = Test.None.class /* no exception expected */ )
-    public void TestCustomDisabledPickerColor()
-    {
-        final Color defaultDisabledText =  new DatePickerSettings().getColor(
-                DateArea.DatePickerTextDisabled);
-        final Color defaultDisabledBackground = new DatePickerSettings().getColor(
-                DateArea.TextFieldBackgroundDisabled);
-
-        DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
-        settings.setColor(DateArea.DatePickerTextDisabled, Color.yellow);
-        settings.setColor(DateArea.TextFieldBackgroundDisabled, Color.blue);
-
-        DatePicker picker = new DatePicker(settings);
-
-        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
-        picker.setEnabled(false);
-        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
-
-        picker.setSettings(new DatePickerSettings(Locale.ENGLISH));
-        validateDatePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
-
-        picker.getSettings().setColor(DateArea.DatePickerTextDisabled, Color.yellow);
-        validateDatePickerDisabledColor(picker, Color.yellow, defaultDisabledBackground);
-        picker.getSettings().setColor(DateArea.TextFieldBackgroundDisabled, Color.blue);
-        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
-        picker.setEnabled(true);
-        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
-
-        picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
-        validateDatePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
-    }
-
-    void validateDatePickerDisabledColor(DatePicker picker, Color disabledTextColor, Color disabledBackground)
-    {
-        final Color validText = new DatePickerSettings().getColor(
-                DatePickerSettings.DateArea.DatePickerTextValidDate);
-        final Color enabledBackground = new DatePickerSettings().getColor(
-                DateArea.TextFieldBackgroundValidDate);
-
-        assertTrue(picker.getComponentDateTextField().getForeground().equals(validText));
-        assertFalse(picker.getComponentDateTextField().getForeground().equals(disabledTextColor));
-        assertTrue(picker.getComponentDateTextField().getDisabledTextColor().equals(disabledTextColor));
-        assertFalse(picker.getComponentDateTextField().getDisabledTextColor().equals(validText));
-        if (picker.isEnabled()) {
-            assertTrue(picker.getComponentDateTextField().getBackground().equals(enabledBackground));
-            assertFalse(picker.getComponentDateTextField().getBackground().equals(disabledBackground));
-        } else {
-            assertTrue(picker.getComponentDateTextField().getBackground().equals(disabledBackground));
-            assertFalse(picker.getComponentDateTextField().getBackground().equals(enabledBackground));
-        }
-    }
-
-    // helper functions
-    Clock getClockFixedToInstant(int year, Month month, int day, int hours, int minutes)
-    {
-        LocalDateTime fixedInstant = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hours,minutes));
-        return Clock.fixed(fixedInstant.toInstant(ZoneOffset.UTC), ZoneId.of("Z"));
     }
 
 }

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestDatePicker.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestDatePicker.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.github.lgooddatepicker.components;
+
+import com.github.lgooddatepicker.TestHelpers;
+import java.awt.Color;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.Locale;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class TestDatePicker
+{
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockDateSettings() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        DatePickerSettings settings = new DatePickerSettings();
+        assertTrue("Default clock must be available", settings.getClock() != null);
+        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+        settings = new DatePickerSettings(Locale.ENGLISH);
+        assertTrue("Default clock must be available", settings.getClock() != null);
+        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+        Clock myClock = Clock.systemUTC();
+        settings.setClock(myClock);
+        assertTrue("Set clock must be returned", settings.getClock() == myClock);
+        settings.setClock(TestHelpers.getClockFixedToInstant(1993, Month.MARCH, 15, 12, 00));
+        settings.setDefaultYearMonth(null);
+        YearMonth defaultyearmonth = (YearMonth) TestHelpers.accessPrivateMethod(DatePickerSettings.class, "zGetDefaultYearMonthAsUsed").invoke(settings);
+        assertTrue(defaultyearmonth.getYear() == 1993);
+        assertTrue(defaultyearmonth.getMonth() == Month.MARCH);
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockDatePicker()
+    {
+        DatePicker picker = new DatePicker();
+        assertTrue(picker.getDate() == null);
+        DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
+        settings.setClock(TestHelpers.getClockFixedToInstant(1995, Month.OCTOBER, 31, 14, 33));
+        picker = new DatePicker(settings);
+        picker.setDateToToday();
+        assertTrue("Picker must have set a date of 1995-10-31", picker.getDate().equals(LocalDate.of(1995, Month.OCTOBER, 31)));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomDisabledPickerColor()
+    {
+        final Color defaultDisabledText =  new DatePickerSettings().getColor(
+                DatePickerSettings.DateArea.DatePickerTextDisabled);
+        final Color defaultDisabledBackground = new DatePickerSettings().getColor(
+                DatePickerSettings.DateArea.TextFieldBackgroundDisabled);
+
+        DatePickerSettings settings = new DatePickerSettings(Locale.ENGLISH);
+        settings.setColor(DatePickerSettings.DateArea.DatePickerTextDisabled, Color.yellow);
+        settings.setColor(DatePickerSettings.DateArea.TextFieldBackgroundDisabled, Color.blue);
+
+        DatePicker picker = new DatePicker(settings);
+
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+        picker.setEnabled(false);
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+
+        picker.setSettings(new DatePickerSettings(Locale.ENGLISH));
+        validateDatePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
+
+        picker.getSettings().setColor(DatePickerSettings.DateArea.DatePickerTextDisabled, Color.yellow);
+        validateDatePickerDisabledColor(picker, Color.yellow, defaultDisabledBackground);
+        picker.getSettings().setColor(DatePickerSettings.DateArea.TextFieldBackgroundDisabled, Color.blue);
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+        picker.setEnabled(true);
+        validateDatePickerDisabledColor(picker, Color.yellow, Color.blue);
+
+        picker = new DatePicker(new DatePickerSettings(Locale.ENGLISH));
+        validateDatePickerDisabledColor(picker, defaultDisabledText, defaultDisabledBackground);
+    }
+
+    void validateDatePickerDisabledColor(DatePicker picker, Color disabledTextColor, Color disabledBackground)
+    {
+        final Color validText = new DatePickerSettings().getColor(
+                DatePickerSettings.DateArea.DatePickerTextValidDate);
+        final Color enabledBackground = new DatePickerSettings().getColor(
+                DatePickerSettings.DateArea.TextFieldBackgroundValidDate);
+
+        assertTrue(picker.getComponentDateTextField().getForeground().equals(validText));
+        assertFalse(picker.getComponentDateTextField().getForeground().equals(disabledTextColor));
+        assertTrue(picker.getComponentDateTextField().getDisabledTextColor().equals(disabledTextColor));
+        assertFalse(picker.getComponentDateTextField().getDisabledTextColor().equals(validText));
+        if (picker.isEnabled()) {
+            assertTrue(picker.getComponentDateTextField().getBackground().equals(enabledBackground));
+            assertFalse(picker.getComponentDateTextField().getBackground().equals(disabledBackground));
+        } else {
+            assertTrue(picker.getComponentDateTextField().getBackground().equals(disabledBackground));
+            assertFalse(picker.getComponentDateTextField().getBackground().equals(enabledBackground));
+        }
+    }
+
+}

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestTimePicker.java
@@ -22,6 +22,7 @@
  */
 package com.github.lgooddatepicker.components;
 
+import com.github.lgooddatepicker.TestHelpers;
 import com.github.lgooddatepicker.components.TimePickerSettings.TimeArea;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -31,6 +32,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.time.Clock;
+import java.time.Month;
+import java.time.ZoneId;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -43,6 +47,39 @@ import java.awt.Color;
  * Tests for the TimePicker component features
  */
 public class TestTimePicker {
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockTimeSettings() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException
+    {
+        TimePickerSettings settings = new TimePickerSettings();
+        assertTrue("Default clock must be available", settings.getClock() != null);
+        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+        settings = new TimePickerSettings(Locale.ENGLISH);
+        assertTrue("Default clock must be available", settings.getClock() != null);
+        assertTrue("Default clock must be in system default time zone", settings.getClock().getZone().equals(ZoneId.systemDefault()));
+        Clock myClock = Clock.systemUTC();
+        settings.setClock(myClock);
+        assertTrue("Set clock must be returned", settings.getClock() == myClock);
+        LocalTime initialTime = (LocalTime) TestHelpers.readPrivateField(TimePickerSettings.class, settings, "initialTime");
+        assertTrue("intialtime is null as long as setInitialTimeToNow() has not been called", initialTime == null);
+        settings.setClock(TestHelpers.getClockFixedToInstant(2000, Month.JANUARY, 1, 15,55));
+        settings.setInitialTimeToNow();
+        initialTime = (LocalTime) TestHelpers.readPrivateField(TimePickerSettings.class, settings, "initialTime");
+        assertTrue("intialtime is not null after call to as long as setInitialTimeToNow()", initialTime != null);
+        assertTrue("intialtime must be 15:55 / 3:55pm", initialTime.equals(LocalTime.of(15, 55)));
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestCustomClockTimePicker()
+    {
+        TimePicker picker = new TimePicker();
+        assertTrue(picker.getTime() == null);
+        TimePickerSettings settings = new TimePickerSettings(Locale.ENGLISH);
+        settings.setClock(TestHelpers.getClockFixedToInstant(1995, Month.OCTOBER, 31, 14, 33));
+        picker = new TimePicker(settings);
+        picker.setTimeToNow();
+        assertTrue("Picker must have set a time of 14:33 / 2:33pm", picker.getTime().equals(LocalTime.of(14, 33)));
+    }
 
     /**
      * Basic test of the time picker functions

--- a/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
@@ -1,7 +1,8 @@
+package com.github.lgooddatepicker.zinternaltools;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import com.github.lgooddatepicker.zinternaltools.InternalUtilities;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;


### PR DESCRIPTION
# This *PR* provides
* Cleanup of test packages :package::broom:
   * Move tests from *default* package into *lgooddatepicker* package 2cab4d0
   *  Move `DatePicker`, `TimePicker` and `CalendarPanel` tests into their own test classes cfb7412

