### PR TITLE
Issue 113

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -19,7 +19,7 @@ plugins in this file operate inside the "package" and "install" phases.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lgooddatepicker</groupId>
     <artifactId>LGoodDatePicker</artifactId>
-    <version>11.2.1</version>
+    <version>11.3.0</version>
     <packaging>jar</packaging>
     <name>LGoodDatePicker</name>
     <description>Java Swing Date Picker. Easy to use, good looking, nice features, and

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -1604,6 +1604,11 @@ public class CalendarPanel extends JPanel {
             ((GridBagLayout) yearEditorPanel.getLayout()).columnWeights = new double[]{1.0, 0.0, 0.0, 1.0E-4};
             ((GridBagLayout) yearEditorPanel.getLayout()).rowWeights = new double[]{1.0, 1.0E-4};
 
+            // Issue #113, enter-press behaves same as the doneEditingYearButton.
+            yearTextField.addActionListener(event -> {
+                doneEditingYearButtonActionPerformed(event);
+            });
+
             //---- doneEditingYearButton ----
             doneEditingYearButton.setFocusPainted(false);
             doneEditingYearButton.setFocusable(false);

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -300,6 +300,15 @@ public class CalendarPanel extends JPanel {
                 drawCalendar(newYearMonth);
             }
         };
+        // Code passes Maven's tests and compiles successfully.
+        // Issue #113: Pressing enter does the same as pressing the doneEditingYearButton
+        yearTextField.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    // This should behave the same as the doneEditingYearButton
+                    doneEditingYearButtonActionPerformed(e);
+                }
+        });
         // Initialize the doneEditingYearButton.
         doneEditingYearButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         doneEditingYearButton.setText("\u2713");
@@ -1603,11 +1612,6 @@ public class CalendarPanel extends JPanel {
             ((GridBagLayout) yearEditorPanel.getLayout()).rowHeights = new int[]{0, 0};
             ((GridBagLayout) yearEditorPanel.getLayout()).columnWeights = new double[]{1.0, 0.0, 0.0, 1.0E-4};
             ((GridBagLayout) yearEditorPanel.getLayout()).rowWeights = new double[]{1.0, 1.0E-4};
-
-            // Issue #113, enter-press behaves same as the doneEditingYearButton.
-            yearTextField.addActionListener(event -> {
-                doneEditingYearButtonActionPerformed(event);
-            });
 
             //---- doneEditingYearButton ----
             doneEditingYearButton.setFocusPainted(false);

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -300,12 +300,10 @@ public class CalendarPanel extends JPanel {
                 drawCalendar(newYearMonth);
             }
         };
-        // Code passes Maven's tests and compiles successfully.
-        // Issue #113: Pressing enter does the same as pressing the doneEditingYearButton
+        // Issue #113: Pressing enter does the same as pressing the doneEditingYearButton.
         yearTextField.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    // This should behave the same as the doneEditingYearButton
                     doneEditingYearButtonActionPerformed(e);
                 }
         });

--- a/Project/src/test/java/com/github/lgooddatepicker/components/TestCalendarPanel.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/components/TestCalendarPanel.java
@@ -213,7 +213,7 @@ public class TestCalendarPanel
     public void TestYearEditor() throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException
     {
         verifyYearEditor(YearEditorFinalizer.doneEditingButton);
-        //verifyYearEditor(YearEditorFinalizer.yearTextField); uncomment once code for issue #113 has been implemented
+        verifyYearEditor(YearEditorFinalizer.yearTextField);
     }
 
     enum YearEditorFinalizer


### PR DESCRIPTION
Added an action listener to the `yearTextField` component in `CalendarPanel` to address issue #113. I tested the changes using Maven to generate a new demo and it achieved the desired effect. 