### PR TITLE
Add UI test for issue 113

### DIFF
--- a/Project/src/test/java/com/github/lgooddatepicker/TestGithubIssues.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestGithubIssues.java
@@ -32,10 +32,14 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.MenuElement;
 import javax.swing.WindowConstants;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -76,7 +80,7 @@ public class TestGithubIssues {
                 assertFalse("DatePicker must not have an open popup.", date_picker.isPopupOpen());
                 Thread.sleep(10);
                 date_picker.openPopup();
-                Thread.sleep(80);
+                Thread.sleep(100);
                 assertTrue("DatePicker must have an open popup.", date_picker.isPopupOpen());
                 testWin.dispatchEvent(new WindowEvent(testWin, WindowEvent.WINDOW_CLOSING));
                 Thread.sleep(100);
@@ -223,8 +227,8 @@ public class TestGithubIssues {
                     bot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                     bot.waitForIdle();
                     bot.delay(50);
-                    assertTrue(popupYear.isVisible() == true);
-                    assertTrue(popupMonth.isVisible() == false);
+                    assertTrue("YearPopup is not visible, iteration "+i, popupYear.isVisible() == true);
+                    assertTrue("MonthPopup is not invisible, iteration "+i, popupMonth.isVisible() == false);
                     bot.delay(51);
                 }
                 else
@@ -234,8 +238,8 @@ public class TestGithubIssues {
                     bot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                     bot.waitForIdle();
                     bot.delay(50);
-                    assertTrue(popupYear.isVisible() == false);
-                    assertTrue(popupMonth.isVisible() == true);
+                    assertTrue("YearPopup is not invisible, iteration "+i, popupYear.isVisible() == false);
+                    assertTrue("MonthPopup is not visible, iteration "+i, popupMonth.isVisible() == true);
                     bot.keyPress(KeyEvent.VK_ESCAPE);
                     bot.delay(51);
                 }
@@ -276,6 +280,109 @@ public class TestGithubIssues {
         else {
             assertTrue("False positive! Text should have invalid color: "+date_picker.getText(), textfieldcolor == invalidDate);
             assertTrue("False positive! Text should not have valid color: "+date_picker.getText(), textfieldcolor != validDate);
+        }
+    }
+
+    @Test( expected = Test.None.class /* no exception expected */ )
+    public void TestIssue113() throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException, AWTException
+    {
+        if (!TestHelpers.isUiAvailable())
+        {
+            // don't run under CI
+            System.out.println("TestIssue113 requires UI to run and was skipped");
+        }
+        org.junit.Assume.assumeTrue(TestHelpers.isUiAvailable());
+
+        // Verify year editing is finihed when enter key is pressed while focusing
+
+        DatePickerSettings dateSettings = new DatePickerSettings(Locale.ENGLISH);
+        CalendarPanel testPanel = new CalendarPanel(dateSettings);
+
+        try ( AutoDisposeFrame testWin = new AutoDisposeFrame() ) {
+            testWin.add(testPanel);
+            testWin.pack();
+            testWin.setVisible(true);
+
+            java.awt.Robot bot = new java.awt.Robot();
+            bot.waitForIdle();
+            bot.delay(100);
+
+            JPanel monthAndYearInnerPanel = (JPanel) TestHelpers.readPrivateField(CalendarPanel.class, testPanel, "monthAndYearInnerPanel");
+            JPanel yearEditorPanel = (JPanel) TestHelpers.readPrivateField(CalendarPanel.class, testPanel, "yearEditorPanel");
+
+            // monthAndYearInnerPanel invisible as default
+            assertTrue(!monthAndYearInnerPanel.isAncestorOf(yearEditorPanel));
+
+            JLabel labelYear = (JLabel) TestHelpers.readPrivateField(CalendarPanel.class, testPanel, "labelYear");
+            final java.awt.Point yearScreenLoc = labelYear.getLocationOnScreen();
+            bot.mouseMove(yearScreenLoc.x+10, yearScreenLoc.y+5);
+
+            JPopupMenu popupYear = (JPopupMenu) TestHelpers.readPrivateField(CalendarPanel.class, testPanel, "popupYear");
+            assertTrue(popupYear.isVisible() == false);
+
+            // Open year popup
+            bot.mouseMove(yearScreenLoc.x+10, yearScreenLoc.y+5);
+            bot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            bot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            bot.waitForIdle();
+            bot.delay(80);
+
+            // monthAndYearInnerPanel still invisible
+            assertTrue(!monthAndYearInnerPanel.isAncestorOf(yearEditorPanel));
+
+            assertTrue(popupYear.isVisible() == true);
+            boolean found = false;
+            for (MenuElement elem : popupYear.getSubElements())
+            {
+                JMenuItem menuItem = (JMenuItem)elem.getComponent();
+                if (menuItem.getText().equals("( . . . )"))
+                {
+                    final java.awt.Point dotLabelPos = menuItem.getLocationOnScreen();
+                    bot.mouseMove(dotLabelPos.x+10, dotLabelPos.y+5);
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found);
+            bot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            bot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            bot.waitForIdle();
+            bot.delay(80);
+
+            // monthAndYearInnerPanel now visible
+            assertTrue(monthAndYearInnerPanel.isAncestorOf(yearEditorPanel));
+
+            // do not access yearTextField directly here, as events triggered by the text
+            // change will result in deadlock due to concurrent access to the UI
+            bot.keyPress(KeyEvent.VK_BACK_SPACE);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_BACK_SPACE);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_BACK_SPACE);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_BACK_SPACE);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_BACK_SPACE);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_2);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_0);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_0);
+            bot.waitForIdle();
+            bot.keyPress(KeyEvent.VK_5);
+
+            bot.waitForIdle();
+            bot.delay(80);
+
+            bot.keyPress(KeyEvent.VK_ENTER);
+            bot.waitForIdle();
+            bot.delay(80);
+
+            // monthAndYearInnerPanel now invisible
+            assertTrue(!monthAndYearInnerPanel.isAncestorOf(yearEditorPanel));
+            assertTrue("labelYear has wrong text: "+labelYear.getText(), labelYear.getText().equals("2005"));
+            assertTrue("labelYear has wrong text: "+labelYear.getText(), !labelYear.getText().equals(String.valueOf(LocalDate.now().getYear())));
         }
     }
 


### PR DESCRIPTION
# This *PR* provides
* an UI test verifying that pressing the enter key in the custom year editor finalizes editing.
  The correct key handling was introduced in #130