### PR TITLE
Fix variable declarations modifier order

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -105,37 +105,37 @@ public class CalendarPanel extends JPanel {
      * constantFirstWeekdayLabelCell, This constant indicates the location of the first weekday
      * label inside of the center panel.
      */
-    static private final Point constantFirstWeekdayLabelCell = new Point(4, 2);
+    private static final Point constantFirstWeekdayLabelCell = new Point(4, 2);
 
     /**
      * constantFirstWeekNumberLabelCell, This constant indicates the location of the first week
      * number label inside of the center panel.
      */
-    static private final Point constantFirstWeekNumberLabelCell = new Point(2, 6);
+    private static final Point constantFirstWeekNumberLabelCell = new Point(2, 6);
 
     /**
      * constantFirstDateLabelCell, This constant indicates the location of the first date label
      * inside of the center panel.
      */
-    static private final Point constantFirstDateLabelCell = new Point(4, 6);
+    private static final Point constantFirstDateLabelCell = new Point(4, 6);
 
     /**
      * constantSizeOfCenterPanelBorders, This constant indicates the (total) size of all the borders
      * in the center panel, in pixels.
      */
-    static private final Dimension constantSizeOfCenterPanelBorders = new Dimension(2, 5);
+    private static final Dimension constantSizeOfCenterPanelBorders = new Dimension(2, 5);
 
     /**
      * constantTopLeftLabelCell, This constant indicates the location of the topLeftLabel inside the
      * center panel.
      */
-    static private final Point constantTopLeftLabelCell = new Point(2, 2);
+    private static final Point constantTopLeftLabelCell = new Point(2, 2);
 
     /**
      * constantWeekNumberLabelInsets, This is the size of the border of the week number labels, in
      * pixels.
      */
-    static private final Insets constantWeekNumberLabelInsets = new Insets(0, 6, 0, 5);
+    private static final Insets constantWeekNumberLabelInsets = new Insets(0, 6, 0, 5);
 
     /**
      * displayedSelectedDate, This stores a date that will be highlighted in the calendar as the

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanelBeanInfo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanelBeanInfo.java
@@ -87,7 +87,7 @@ public class CalendarPanelBeanInfo extends SimpleBeanInfo {
      * zPropertyDescriptorArray, This holds the array of BeanInfo property descriptors. This is
      * initialized when the class is first loaded, and not changed afterwards.
      */
-    static private PropertyDescriptor[] zPropertyDescriptorArray;
+    private static PropertyDescriptor[] zPropertyDescriptorArray;
 
     /**
      * Static Initializer, This code is run when the class is first accessed or instantiated. This

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerBeanInfo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerBeanInfo.java
@@ -88,7 +88,7 @@ public class DatePickerBeanInfo extends SimpleBeanInfo {
      * zPropertyDescriptorArray, This holds the array of BeanInfo property descriptors. This is
      * initialized when the class is first loaded, and not changed afterwards.
      */
-    static private PropertyDescriptor[] zPropertyDescriptorArray;
+    private static PropertyDescriptor[] zPropertyDescriptorArray;
 
     /**
      * Static Initializer, This code is run when the class is first accessed or instantiated. This

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DateTimePickerBeanInfo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DateTimePickerBeanInfo.java
@@ -88,7 +88,7 @@ public class DateTimePickerBeanInfo extends SimpleBeanInfo {
      * zPropertyDescriptorArray, This holds the array of BeanInfo property descriptors. This is
      * initialized when the class is first loaded, and not changed afterwards.
      */
-    static private PropertyDescriptor[] zPropertyDescriptorArray;
+    private static PropertyDescriptor[] zPropertyDescriptorArray;
 
     /**
      * Static Initializer, This code is run when the class is first accessed or instantiated. This

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerBeanInfo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerBeanInfo.java
@@ -88,7 +88,7 @@ public class TimePickerBeanInfo extends SimpleBeanInfo {
      * zPropertyDescriptorArray, This holds the array of BeanInfo property descriptors. This is
      * initialized when the class is first loaded, and not changed afterwards.
      */
-    static private PropertyDescriptor[] zPropertyDescriptorArray;
+    private static PropertyDescriptor[] zPropertyDescriptorArray;
 
     /**
      * Static Initializer, This code is run when the class is first accessed or instantiated. This

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -1038,7 +1038,7 @@ public class TimePickerSettings {
         /**
          * minutes, This holds the number of minutes represented by the time increment.
          */
-        final public int minutes;
+        public final int minutes;
 
         /**
          * Constructor. This takes the number of minutes represented by the time increment.

--- a/Project/src/main/java/com/github/lgooddatepicker/demo/TableEditorsDemo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/demo/TableEditorsDemo.java
@@ -228,7 +228,7 @@ public class TableEditorsDemo extends JPanel {
         /**
          * dateTimeColumnIndex, This specifies the index of the date time column.
          */
-        static public int dateTimeColumnIndex = 2;
+        public static int dateTimeColumnIndex = 2;
 
         /**
          * data, This is the initial data that is contained in the table cells.

--- a/Project/src/main/java/com/github/lgooddatepicker/durationpicker_underconstruction/DurationConverter.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/durationpicker_underconstruction/DurationConverter.java
@@ -16,7 +16,7 @@ public class DurationConverter {
      *
      * Note: This function will return null if the string cannot be parsed for any reason.
      */
-    static public Duration convertStringToDuration(String text, DurationConverterSettings settings) {
+    public static Duration convertStringToDuration(String text, DurationConverterSettings settings) {
         if (text == null) {
             return null;
         }
@@ -104,7 +104,7 @@ public class DurationConverter {
      * This function will return an empty string if the duration is null or less than zero. This
      * function will never return null.
      */
-    static public String convertStringFromDuration(
+    public static String convertStringFromDuration(
             Duration duration, DurationConverterSettings settings) {
         if ((duration == null) || (duration.isNegative())) {
             return "";

--- a/Project/src/main/java/com/github/lgooddatepicker/durationpicker_underconstruction/DurationUnit.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/durationpicker_underconstruction/DurationUnit.java
@@ -14,8 +14,8 @@ public enum DurationUnit {
     Month((int) ChronoUnit.MONTHS.getDuration().getSeconds()),
     Year((int) ChronoUnit.YEARS.getDuration().getSeconds());
 
-    final public int inSeconds;
-    final public int thirtyMinutesInSeconds = (30 * 60);
+    public final int inSeconds;
+    public final int thirtyMinutesInSeconds = (30 * 60);
 
     DurationUnit(int secondsConstant) {
         inSeconds = secondsConstant;

--- a/Project/src/main/java/com/github/lgooddatepicker/optionalusertools/DateHighlightPolicy.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/optionalusertools/DateHighlightPolicy.java
@@ -29,6 +29,6 @@ public interface DateHighlightPolicy {
      *
      * Dates that are passed to this function will never be null.
      */
-    abstract public HighlightInformation getHighlightInformationOrNull(LocalDate date);
+    public abstract HighlightInformation getHighlightInformationOrNull(LocalDate date);
 
 }

--- a/Project/src/main/java/com/github/lgooddatepicker/optionalusertools/PickerUtilities.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/optionalusertools/PickerUtilities.java
@@ -75,7 +75,7 @@ public class PickerUtilities {
      * returns true if both of the supplied dates contain a date and represent the same date.
      * Otherwise this returns false.
      */
-    static public boolean isSameLocalDate(LocalDate first, LocalDate second) {
+    public static boolean isSameLocalDate(LocalDate first, LocalDate second) {
         // If both values are null, return true.
         if (first == null && second == null) {
             return true;
@@ -177,7 +177,7 @@ public class PickerUtilities {
      * characters. Years before or after that range will output longer strings. If the date is null,
      * this will return an empty string ("").
      */
-    static public String localDateToString(LocalDate date) {
+    public static String localDateToString(LocalDate date) {
         return localDateToString(date, "");
     }
 
@@ -187,7 +187,7 @@ public class PickerUtilities {
      * characters. Years before or after that range will output longer strings. If the date is null,
      * this will return the value of emptyDateString.
      */
-    static public String localDateToString(LocalDate date, String emptyDateString) {
+    public static String localDateToString(LocalDate date, String emptyDateString) {
         return (date == null) ? emptyDateString : date.toString();
     }
 

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/CalculateMinimumDateFieldSize.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/CalculateMinimumDateFieldSize.java
@@ -50,7 +50,7 @@ public class CalculateMinimumDateFieldSize {
      * greater than four digits, or by using BC years. This function assumes four digit Common Era
      * years, in performing its calculations.
      */
-    static public int getFormattedDateWidthInPixels(DateTimeFormatter formatCE, Locale locale,
+    public static int getFormattedDateWidthInPixels(DateTimeFormatter formatCE, Locale locale,
             Font fontValidDate, int numberOfExtraCharacters) {
         // Create the font metrics that will be used in the calculation.
         JTextField textField = new JTextField();
@@ -103,7 +103,7 @@ public class CalculateMinimumDateFieldSize {
      * "tied" as the "longest month", then the longest month that is closest to the end of the year
      * will be the one that is returned.
      */
-    static private Month getLongestTextMonthInLocale(Locale locale, FontMetrics fontMetrics) {
+    private static Month getLongestTextMonthInLocale(Locale locale, FontMetrics fontMetrics) {
         // Get the "formatting names" of all the months for this locale.
         // Request the capitalized long version of the translated month names.
         String[] formattingMonthNames = ExtraDateStrings.getFormattingMonthNamesArray(

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/CalculateMinimumTimeFieldSize.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/CalculateMinimumTimeFieldSize.java
@@ -27,7 +27,7 @@ public class CalculateMinimumTimeFieldSize {
      * calculation, by supplying a nonzero value for the parameter numberOfExtraCharacters. This
      * parameter can also be used with a negative value to reduce the size that is returned.
      */
-    static public int getFormattedTimeWidthInPixels(DateTimeFormatter formatForDisplayTime,
+    public static int getFormattedTimeWidthInPixels(DateTimeFormatter formatForDisplayTime,
             Font fontValidTime, int numberOfExtraCharacters) {
         // Create the font metrics that will be used in the calculation.
         JTextField textField = new JTextField();

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/CustomPopup.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/CustomPopup.java
@@ -279,7 +279,7 @@ public class CustomPopup extends Popup
      * implement this interface to be notified when the CustomPopup is closed. The implementing
      * class should pass itself into the CustomPopup constructor.
      */
-    static public interface CustomPopupCloseListener {
+    public static interface CustomPopupCloseListener {
 
         /**
          * zEventCustomPopupWasClosed, This will be called whenever the CustomPopup is closed,

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
@@ -19,7 +19,7 @@ public class ExtraDateStrings {
      * extraParsingFormatsForLanguage_en, This is a constant list of extra parsing formats, which
      * are used for parsing dates in an English locale.
      */
-    final static private String[] extraParsingFormatsForLanguage_en = new String[]{
+    private static final String[] extraParsingFormatsForLanguage_en = new String[]{
         "M/d/u", "dMMMuu", "dMMMuuuu", "d MMM uu", "d MMM uuuu", "MMM d, u", "MMM d u",
         "MMM d, yyyy G"};
 
@@ -27,7 +27,7 @@ public class ExtraDateStrings {
      * extraParsingFormatsForLanguage_ru, This is a constant list of extra parsing formats, which
      * are used for parsing dates in a Russian locale.
      */
-    final static private String[] extraParsingFormatsForLanguage_ru = new String[]{
+    private static final String[] extraParsingFormatsForLanguage_ru = new String[]{
         "d MMM uuuu"};
 
     /**
@@ -37,7 +37,7 @@ public class ExtraDateStrings {
      * this array should only be used for visual reference. This can be used for comparison to
      * ensure that the general solution is functioning correctly.
      */
-    final static public String[] monthsNamesForLanguage_ru = new String[]{"январь", "февраль",
+    public static final String[] monthsNamesForLanguage_ru = new String[]{"январь", "февраль",
         "март", "апрель", "май", "июнь", "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"};
 
     /**

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraTimeStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraTimeStrings.java
@@ -16,7 +16,7 @@ public class ExtraTimeStrings {
      * extraParsingFormatsForLanguage_en, This is a constant list of extra parsing formats, which
      * are used for parsing times in an English locale.
      */
-    final static private String[] extraParsingFormatsForLanguage_en = new String[]{
+    private static final String[] extraParsingFormatsForLanguage_en = new String[]{
         "h:ma", "h.ma", "ha"};
 
     /**

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalConstants.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalConstants.java
@@ -4,6 +4,6 @@ import java.awt.Color;
 
 public class InternalConstants {
 
-    static public Color colorEditableTextFieldBorder = new Color(122, 138, 153);
-    static public Color colorNotEditableTextFieldBorder = new Color(184, 207, 229);
+    public static Color colorEditableTextFieldBorder = new Color(122, 138, 153);
+    public static Color colorNotEditableTextFieldBorder = new Color(184, 207, 229);
 }

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
@@ -70,7 +70,7 @@ public class InternalUtilities {
      * day of February, April, June, September, or November. The 30th day of February. Or the 29th
      * day of February on any year that is not a leap year.
      */
-    static public boolean doesParsedDateMatchText(LocalDate parsedDate, String text,
+public static boolean doesParsedDateMatchText(LocalDate parsedDate, String text,
             DateTimeFormatter usedFormatter) {
         if (parsedDate == null || text == null) {
             return false;
@@ -184,7 +184,7 @@ public class InternalUtilities {
      * window is supplied, then the the monitor that contains the window will be used. If a window
      * is not supplied, then the primary monitor will be used.
      */
-    static public Insets getScreenInsets(Window windowOrNull) {
+    public static Insets getScreenInsets(Window windowOrNull) {
         Insets insets;
         if (windowOrNull == null) {
             insets = Toolkit.getDefaultToolkit().getScreenInsets(GraphicsEnvironment
@@ -203,7 +203,7 @@ public class InternalUtilities {
      * the the monitor that contains the window will be used. If a window is not supplied, then the
      * primary monitor will be used.
      */
-    static public Rectangle getScreenTotalArea(Window windowOrNull) {
+    public static Rectangle getScreenTotalArea(Window windowOrNull) {
         Rectangle bounds;
         if (windowOrNull == null) {
             GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
@@ -221,7 +221,7 @@ public class InternalUtilities {
      * then the the monitor that contains the window will be used. If a window is not supplied, then
      * the primary monitor will be used.
      */
-    static public Rectangle getScreenWorkingArea(Window windowOrNull) {
+    public static Rectangle getScreenWorkingArea(Window windowOrNull) {
         Insets insets;
         Rectangle bounds;
         if (windowOrNull == null) {
@@ -301,7 +301,7 @@ public class InternalUtilities {
      * kinds of mistakes. If the parsed text does not match the day of the month (and year) of the
      * parsed date, then this function will return null.
      */
-    static public LocalDate getParsedDateOrNull(String text,
+    public static LocalDate getParsedDateOrNull(String text,
         DateTimeFormatter displayFormatterAD, DateTimeFormatter displayFormatterBC, 
         ArrayList<DateTimeFormatter> parsingFormatters) {
         if (text == null || text.trim().isEmpty()) {
@@ -387,7 +387,7 @@ public class InternalUtilities {
      * getConstraints, This returns a grid bag constraints object that can be used for placing a
      * component appropriately into a grid bag layout.
      */
-    static public GridBagConstraints getConstraints(int gridx, int gridy) {
+    public static GridBagConstraints getConstraints(int gridx, int gridy) {
         GridBagConstraints gc = new GridBagConstraints();
         gc.fill = GridBagConstraints.BOTH;
         gc.gridx = gridx;
@@ -400,7 +400,7 @@ public class InternalUtilities {
      * vetoed. Note that veto policies do not have any say about null dates, so this function always
      * returns false for null dates.
      */
-    static public boolean isDateVetoed(DateVetoPolicy policy, LocalDate date) {
+    public static boolean isDateVetoed(DateVetoPolicy policy, LocalDate date) {
         if (policy == null || date == null) {
             return false;
         }
@@ -411,7 +411,7 @@ public class InternalUtilities {
      * isMouseWithinComponent, This returns true if the mouse is inside of the specified component,
      * otherwise returns false.
      */
-    static public boolean isMouseWithinComponent(Component component) {
+    public static boolean isMouseWithinComponent(Component component) {
         if (!component.isVisible()) {
             // component.getLocationOnScreen() will throw an
             // IllegalComponentStateException if the component
@@ -438,7 +438,7 @@ public class InternalUtilities {
      * within the bounds of the supplied string. If the beginIndex is greater than or equal to
      * endIndexExclusive, then this will return an empty string.
      */
-    static public String safeSubstring(String text, int beginIndex, int endIndexExclusive) {
+    public static String safeSubstring(String text, int beginIndex, int endIndexExclusive) {
         if (text == null) {
             return null;
         }

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/MouseLiberalAdapter.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/MouseLiberalAdapter.java
@@ -142,7 +142,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mousePressed, Final function. Handles mouse pressed events.
      */
     @Override
-    final public void mousePressed(MouseEvent e) {
+    public final void mousePressed(MouseEvent e) {
         // Record that the component is "pressed down".
         isComponentPressedDown = true;
         // Call the mouse press event.
@@ -154,7 +154,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * liberal single clicks, and liberal double clicks.
      */
     @Override
-    final public void mouseReleased(MouseEvent e) {
+    public final void mouseReleased(MouseEvent e) {
         // Check to see if this mouse release completes a liberal single click.
         if (isComponentPressedDown) {
             // A liberal single click has occurred.
@@ -182,7 +182,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mouseEntered, Final function. Handles mouse entered events.
      */
     @Override
-    final public void mouseEntered(MouseEvent e) {
+    public final void mouseEntered(MouseEvent e) {
         // Call the mouse enter event.
         mouseEnter(e);
     }
@@ -191,7 +191,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mouseExited, Final function. Handles mouse exited events.
      */
     @Override
-    final public void mouseExited(MouseEvent e) {
+    public final void mouseExited(MouseEvent e) {
         // Since the mouse left the component, the component is no longer considered "press down".
         isComponentPressedDown = false;
         // Call the mouse exit event.
@@ -202,7 +202,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mouseClicked, Final function. Handles mouse clicked events.
      */
     @Override
-    final public void mouseClicked(MouseEvent e) {
+    public final void mouseClicked(MouseEvent e) {
         // Call the mouse click event.
         mouseClick(e);
     }
@@ -211,7 +211,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mouseWheelMoved, Final function. Handles mouse wheel moved events.
      */
     @Override
-    final public void mouseWheelMoved(MouseWheelEvent e) {
+    public final void mouseWheelMoved(MouseWheelEvent e) {
         // Call the mouse wheel move event.
         mouseWheelMove(e);
     }
@@ -220,7 +220,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mouseDragged, Final function. Handles mouse dragged events.
      */
     @Override
-    final public void mouseDragged(MouseEvent e) {
+    public final void mouseDragged(MouseEvent e) {
         // Call the mouse drag event.
         mouseDrag(e);
     }
@@ -229,7 +229,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
      * mouseMoved, Final function. Handles mouse moved events.
      */
     @Override
-    final public void mouseMoved(MouseEvent e) {
+    public final void mouseMoved(MouseEvent e) {
         // Call the mouse move event.
         mouseMove(e);
     }

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeMenuPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeMenuPanel.java
@@ -50,7 +50,7 @@ public class TimeMenuPanel extends JPanel {
     /**
      * timeListModel, The holds the list model that is used for populating the time list.
      */
-    final private DefaultListModel<String> timeListModel;
+    private final DefaultListModel<String> timeListModel;
 
     public TimeMenuPanel(TimePicker parentTimePicker, TimePickerSettings settings) {
         this.parentTimePicker = parentTimePicker;

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeSpinnerTimer.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeSpinnerTimer.java
@@ -16,34 +16,34 @@ public class TimeSpinnerTimer {
     /**
      * timePicker, This holds the time picker that is associated with this class.
      */
-    final private TimePicker timePicker;
+    private final TimePicker timePicker;
 
     /**
      * timePicker, This holds the number of minutes that should be added or subtracted with each
      * increment of the time picker value. This will typically be -1 or 1.
      */
-    final private int changeAmountMinutes;
+    private final int changeAmountMinutes;
 
     /**
      * timer, This holds the timer associated with this class.
      */
-    final private Timer timer;
+    private final Timer timer;
 
     /**
      * startDelayMillis, This indicates how long the timer should wait before firing its first tick.
      * This value is used to make sure that the user can easily increase or decrease the date picker
      * value by only 1 minute.
      */
-    final private int startDelayMillis = 700;
+    private final int startDelayMillis = 700;
     /**
      * timerRate, This indicates how often the timer should call the tick function, in milliseconds.
      */
-    final private int timerRate = 20;
+    private final int timerRate = 20;
     /**
      * millisForDivisorList, This indicates how long each value in the divisorList should be used,
      * before moving onto the next value in the divisorList.
      */
-    final private int[] millisForDivisorList = new int[]{
+    private final int[] millisForDivisorList = new int[]{
         1800, 900, 400, 400, 400, 400, 400, 0};
     /**
      * divisorList, For as long as any particular index in this array remains in effect, the
@@ -52,7 +52,7 @@ public class TimeSpinnerTimer {
      * changed only once for every 3 calls to the tick function. Higher numbers make the spinner
      * change slower, lower numbers make the spinner change faster.
      */
-    final private int[] divisorList = new int[]{12, 10, 8, 6, 4, 3, 2, 1};
+    private final int[] divisorList = new int[]{12, 10, 8, 6, 4, 3, 2, 1};
     /**
      * startedIndexTimeStamp, This indicates the time that the currently used index in the
      * divisorList started to be used.

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TranslationSource.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TranslationSource.java
@@ -15,13 +15,13 @@ public class TranslationSource {
      * translationResources, This holds the translation properties. This variable is only loaded
      * once, the first time that it is needed.
      */
-    static private Properties translationResources;
+    private static Properties translationResources;
 
     /**
      * propertiesFileName, This holds the name of the properties file.
      */
     //leading / since it is at the root of the jar
-    static final private String propertiesFileName = "/TranslationResources.properties";
+    private static final String propertiesFileName = "/TranslationResources.properties";
 
     /**
      * getTranslation, This returns a local language translation for the text that is represented by

--- a/Project/src/test/java/com/github/lgooddatepicker/TestHelpers.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/TestHelpers.java
@@ -73,7 +73,7 @@ public class TestHelpers
         return !java.awt.GraphicsEnvironment.isHeadless();
     }
 
-    static public void registerUncaughtExceptionHandlerToAllThreads(Thread.UncaughtExceptionHandler handler)
+    public static void registerUncaughtExceptionHandlerToAllThreads(Thread.UncaughtExceptionHandler handler)
     {
         Thread.setDefaultUncaughtExceptionHandler(handler);
         //activeCount is only an estimation

--- a/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
@@ -122,7 +122,7 @@ public class TestParsingMatchFunction {
         checkDate("ddMMuuuuG", "31062019AD", false);
     }
 
-    static private boolean isLeapYear(int year) {
+    private static boolean isLeapYear(int year) {
         if (year % 4 != 0) {
             return false;
         } else if (year % 400 == 0) {
@@ -133,7 +133,7 @@ public class TestParsingMatchFunction {
         return true;
     }
 
-    static private void checkDate(String dateformat, String dateValue, boolean isValidDate) {
+    private static void checkDate(String dateformat, String dateValue, boolean isValidDate) {
         final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(dateformat).toFormatter(Locale.ENGLISH);
         final LocalDate parsedDate = LocalDate.parse(dateValue, formatter);
         final boolean determinedValidity = InternalUtilities.doesParsedDateMatchText(parsedDate, dateValue, formatter);


### PR DESCRIPTION
Fix variable declarations whose modifiers are not in the canonical preferred order (as stated in the Java Language Specification).