### PR TITLE
Drop support for Java 6 and Java 7

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -55,6 +55,14 @@ plugins in this file operate inside the "package" and "install" phases.
     </properties>
 
     <dependencies>
+        <!-- BeansBinding, This is only used in the data binding demo.
+             uncomment this if you want to compile the data binding demo
+        <dependency>
+            <groupId>org.jdesktop</groupId>
+            <artifactId>beansbinding</artifactId>
+            <version>1.2.1</version>
+        </dependency> -->
+
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>

--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -45,23 +45,6 @@ plugins in this file operate inside the "package" and "install" phases.
         <url>git@github.com:LGoodDatePicker/LGoodDatePicker.git</url>
     </scm>
 
-    <!-- ## Instructions for switching between Java 1.8 releases, and Java 1.6 releases. ##
-        Note: The project should only be committed to the GitHub master branch, while configured
-        for Java 1.8.
-
-        * For Java 1.6:
-        * In the POM properties section: Switch the maven source and target to 1.6.
-        * In the POM dependencies section: Uncomment the dependency section for "threetenbp".
-        * Replace the following string in all the project source files:
-          - "import java(dot)time" with "import org.threeten(dot)bp".
-
-        * For Java 1.8:
-        * In the POM properties section: Switch the maven source and target to 1.8.
-        * In the POM dependencies section: Comment out the dependency section for "threetenbp".
-        * Replace the following string in all the project source files:
-          - "import org.threeten(dot)bp" with "import java(dot)time".
-    -->
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -70,25 +53,8 @@ plugins in this file operate inside the "package" and "install" phases.
         <testrunparams>--add-opens java.desktop/java.awt=ALL-UNNAMED</testrunparams> <!-- allows parameters for the test execution to be set via mvn command line -->
         <license.maven.plugin.version>4.1</license.maven.plugin.version>
     </properties>
+
     <dependencies>
-
-        <!-- JSRThreeTen Backport. Uncomment this section when building for target Java 1.6. -->
-        <!--
-        <dependency>
-            <groupId>org.threeten</groupId>
-            <artifactId>threetenbp</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-        -->
-
-        <!-- BeansBinding, This is only used in the data binding demo.
-             uncomment this if you want to compile the data binding demo
-        <dependency>
-            <groupId>org.jdesktop</groupId>
-            <artifactId>beansbinding</artifactId>
-            <version>1.2.1</version>
-        </dependency> -->
-
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>
@@ -96,7 +62,6 @@ plugins in this file operate inside the "package" and "install" phases.
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <profiles>
@@ -109,7 +74,7 @@ plugins in this file operate inside the "package" and "install" phases.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -217,7 +182,7 @@ plugins in this file operate inside the "package" and "install" phases.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>2.22.2</version>
                 <configuration>
                      <argLine>${testrunparams} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                 </configuration>
@@ -226,7 +191,7 @@ plugins in this file operate inside the "package" and "install" phases.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -240,7 +205,7 @@ plugins in this file operate inside the "package" and "install" phases.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.2.0</version>
                 <configuration>
                   <archive>
                     <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
@@ -251,7 +216,7 @@ plugins in this file operate inside the "package" and "install" phases.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <source>8</source>
                     <!-- Turn off errors resulting from the new (strict) Java 8 Javadoc standards. -->
@@ -270,7 +235,7 @@ plugins in this file operate inside the "package" and "install" phases.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -334,7 +299,7 @@ plugins in this file operate inside the "package" and "install" phases.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-artifacts</id>

--- a/Project/src/main/java/com/github/lgooddatepicker/demo/FullDemo.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/demo/FullDemo.java
@@ -1026,17 +1026,13 @@ public class FullDemo {
         String runningJavaVersion = InternalUtilities.getJavaRunningVersionAsString();
         String targetJavaVersion = InternalUtilities.getJavaTargetVersionFromPom();
         String projectVersion = InternalUtilities.getProjectVersionString();
-        boolean isBackport = ("1.6".equals(targetJavaVersion));
         String message = "";
         message += "## Current configuration ##";
-        message += "\nLGoodDatePicker version: \"LGoodDatePicker ";
-        message += (isBackport) ? ("Backport " + projectVersion) : (projectVersion + " (Standard)");
+        message += "\nLGoodDatePicker version: \"LGoodDatePicker " + projectVersion;
         message += "\".";
         message += "\nJava target version: Java " + targetJavaVersion;
         message += "\nJava running version: " + runningJavaVersion;
-        message += "\n\nMinimum Requirements:"
-            + "\n\"LGoodDatePicker Standard\" requires Java 1.8 (or above). "
-            + "\n\"LGoodDatePicker Backport\" requires Java 1.6 or 1.7.";
+        message += "\n\nMinimum Requirements:\nLGoodDatePicker requires Java 8 (or above).";
         panel.messageTextArea.setText(message);
     }
 

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
@@ -523,6 +523,12 @@ public static boolean doesParsedDateMatchText(LocalDate parsedDate, String text,
                 return "Java 7";
             case 52:
                 return "Java 8";
+            case 53:
+                return "Java 9";
+            case 54:
+                return "Java 10";
+            case 55:
+                return "Java 11";
             default:
                 return "Could not find version string for major version: " + majorVersion;
         }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ General Discussion: [Discussion Thread](https://github.com/LGoodDatePicker/LGood
 
 ## News:
 
-* [LGoodDatePicker 11.2.0](https://github.com/LGoodDatePicker/LGoodDatePicker/releases) was released on February 28, 2021. This version adds the Icelandic language translation and the possibility to customize the colors of date and time pickers in disabled state.
+* [LGoodDatePicker 11.2.0](https://github.com/LGoodDatePicker/LGoodDatePicker/releases) was released on February 28, 2021. This version adds the Icelandic language translation and the possibility to customize the colors of date and time pickers in disabled state. This is the last version that supported Java 6 and 7.
 
 * [LGoodDatePicker 11.1.0](https://github.com/LGoodDatePicker/LGoodDatePicker/releases) was released on September 30, 2020. This version adds the possibility to customize the colors used for the mouse hover highlight of the calendar panel labels.
 


### PR DESCRIPTION
This is the implementation for this [issue](https://github.com/LGoodDatePicker/LGoodDatePicker/issues/143).

In the process also updated some dependencies in pom.xml to more current versions.