### PR TITLE
Chore: remove unnecessary boxing/unboxing

### DIFF
--- a/Project/src/main/java/com/privatejgoodies/common/internal/RenderingUtils.java
+++ b/Project/src/main/java/com/privatejgoodies/common/internal/RenderingUtils.java
@@ -100,7 +100,7 @@ public final class RenderingUtils {
         if (drawStringMethod != null) {
             try {
                 drawStringMethod.invoke(null,
-                        c, g, text, Integer.valueOf(x), Integer.valueOf(y));
+                        c, g, text, x, y);
                 return;
             } catch (IllegalArgumentException e) {
                 // Use the BasicGraphicsUtils as fallback

--- a/Project/src/main/java/com/privatejgoodies/forms/layout/CellConstraints.java
+++ b/Project/src/main/java/com/privatejgoodies/forms/layout/CellConstraints.java
@@ -769,12 +769,12 @@ public final class CellConstraints implements Cloneable, Serializable {
         Integer nextInt = decodeInt(tokenizer.nextToken());
         checkArgument(nextInt != null,
                 "First cell constraint element must be a number.");
-        gridX = nextInt.intValue();
+        gridX = nextInt;
         checkArgument(gridX > 0, "The grid x must be a positive number.");
         nextInt = decodeInt(tokenizer.nextToken());
         checkArgument(nextInt != null,
                 "Second cell constraint element must be a number.");
-        gridY = nextInt.intValue();
+        gridY = nextInt;
         checkArgument(gridY > 0, "The grid y must be a positive number.");
         if (!tokenizer.hasMoreTokens()) {
             return;
@@ -785,7 +785,7 @@ public final class CellConstraints implements Cloneable, Serializable {
         if (nextInt != null) {
             // Case: "x, y, w, h" or
             //       "x, y, w, h, hAlign, vAlign"
-            gridWidth = nextInt.intValue();
+            gridWidth = nextInt;
             if (gridWidth <= 0) {
                 throw new IndexOutOfBoundsException(
                         "The grid width must be a positive number.");
@@ -795,7 +795,7 @@ public final class CellConstraints implements Cloneable, Serializable {
                 throw new IllegalArgumentException(
                         "Fourth cell constraint element must be like third.");
             }
-            gridHeight = nextInt.intValue();
+            gridHeight = nextInt;
             if (gridHeight <= 0) {
                 throw new IndexOutOfBoundsException(
                         "The grid height must be a positive number.");
@@ -1175,7 +1175,7 @@ public final class CellConstraints implements Cloneable, Serializable {
             buffer.append(insets);
         }
         if (honorsVisibility != null) {
-            buffer.append(honorsVisibility.booleanValue()
+            buffer.append(honorsVisibility
                     ? "honors visibility"
                     : "ignores visibility");
         }

--- a/Project/src/main/java/com/privatejgoodies/forms/util/FormUtils.java
+++ b/Project/src/main/java/com/privatejgoodies/forms/util/FormUtils.java
@@ -59,9 +59,9 @@ public final class FormUtils {
     public static boolean isLafAqua() {
         ensureValidCache();
         if (cachedIsLafAqua == null) {
-            cachedIsLafAqua = Boolean.valueOf(computeIsLafAqua());
+            cachedIsLafAqua = computeIsLafAqua();
         }
-        return cachedIsLafAqua.booleanValue();
+        return cachedIsLafAqua;
     }
 
     // Caching and Lazily Computing the Laf State *****************************


### PR DESCRIPTION
Remove explicit boxing (wrapping of primitive values in objects) and unboxing (explicit unwrapping of wrapped primitive values).

Explicit manual boxing/unboxing is unnecessary as for Java 5 and later, and can safely be removed.