### PR TITLE
Apply formatting to every PR instead of every push to master

### DIFF
--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -1,10 +1,8 @@
-# Example workflow
-name: Format
+name: Code formatting
 
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    branches: [ master ]
 
 jobs:
 
@@ -15,5 +13,3 @@ jobs:
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"
-          # Recommended if you use MacOS:
-          # githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -752,17 +752,14 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
    * DatePickerSettings.setSizeTextFieldMinimumWidthDefaultOverride().
    */
   void zSetAppropriateTextFieldMinimumWidth() {
-    if (settings == null) {
+    if (settings == null)
+    {
       return;
     }
     Integer programmerSuppliedWidth = settings.getSizeTextFieldMinimumWidth();
     // Determine the appropriate minimum width for the text field.
     int minimumWidthPixels =
-        CalculateMinimumDateFieldSize.getFormattedDateWidthInPixels(
-            settings.getFormatForDatesCommonEra(),
-            settings.getLocale(),
-            settings.getFontValidDate(),
-            0);
+        CalculateMinimumDateFieldSize.getFormattedDateWidthInPixels( settings.getFormatForDatesCommonEra(), settings.getLocale(), settings.getFontValidDate(), 0);
     if (programmerSuppliedWidth != null) {
       if (settings.getSizeTextFieldMinimumWidthDefaultOverride()) {
         minimumWidthPixels = Math.max(programmerSuppliedWidth, minimumWidthPixels);


### PR DESCRIPTION
### I would like to propose the following changes to the code formatting *Github* action:
* Run it on every PR that is created, so that the code is already nicely formatted for the reviewer
* Do **not** run formatting on changes to the master branch. My reasoning for this is as follows:
  * All changes coming through PRs are now already formatted so in that case running it again is unnecessary
  * If there at any point in the future there is an issue with the formatting *Github* action (e.g. a corrupt formatter executable is downloaded) there would be broken commits that have been automatically committed to master
  * Having formatting changes applied to PRs ensures these changed are also reviewed and possible issues with it will be detected early on

@BlakeTNC if you want to keep the formatting on push to *master* I can add it back in.

