### PR TITLE
Format source on push to every branch except master

### DIFF
--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#+refs/heads/})"
         id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
         id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
         id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -9,9 +9,13 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF_NAME})"
+        id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.extract_branch.outputs.branch }}
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -14,11 +14,11 @@ jobs:
         run: echo ${GITHUB_HEAD_REF}
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#+refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
         id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:
-          ref: ${{ steps.extract_branch.outputs.branch }}
+          ref: ${GITHUB_HEAD_REF}
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF_NAME})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -9,6 +9,9 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
+      - name: Print branch name
+        shell: bash
+        run: echo ${GITHUB_HEAD_REF}
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#+refs/heads/})"

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -1,8 +1,9 @@
 name: Code formatting
 
 on:
-  pull_request:
-    branches: [ master ]
+  push:
+    branches-ignore:
+      - master
 
 jobs:
 
@@ -10,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
-        with:
-          ref: ${{ github.head_ref }}
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"

--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -9,16 +9,9 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - name: Print branch name
-        shell: bash
-        run: echo ${GITHUB_HEAD_REF}
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
-        id: extract_branch
       - uses: actions/checkout@v2 # v2 minimum required
         with:
-          ref: ${GITHUB_HEAD_REF}
+          ref: ${{ github.head_ref }}
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -758,14 +758,17 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
    * DatePickerSettings.setSizeTextFieldMinimumWidthDefaultOverride().
    */
   void zSetAppropriateTextFieldMinimumWidth() {
-    if (settings == null)
-    {
+    if (settings == null) {
       return;
     }
     Integer programmerSuppliedWidth = settings.getSizeTextFieldMinimumWidth();
     // Determine the appropriate minimum width for the text field.
     int minimumWidthPixels =
-        CalculateMinimumDateFieldSize.getFormattedDateWidthInPixels( settings.getFormatForDatesCommonEra(), settings.getLocale(), settings.getFontValidDate(), 0);
+        CalculateMinimumDateFieldSize.getFormattedDateWidthInPixels(
+            settings.getFormatForDatesCommonEra(),
+            settings.getLocale(),
+            settings.getFontValidDate(),
+            0);
     if (programmerSuppliedWidth != null) {
       if (settings.getSizeTextFieldMinimumWidthDefaultOverride()) {
         minimumWidthPixels = Math.max(programmerSuppliedWidth, minimumWidthPixels);


### PR DESCRIPTION
PR #156 introduced an issue where the formatted code could not be pushed to the PR by the github action, due to detached HEAD. 🥵 
This issue is now circumvented by having all branches except *master* be formatted on *push* events.