### PR TITLE
Modify the format action to enable manual control of action updates. 

### DIFF
--- a/.github/workflows/googlejavaformat-action.yml
+++ b/.github/workflows/googlejavaformat-action.yml
@@ -1,9 +1,6 @@
 name: Format
 
-on:
-  push:
-    branches-ignore:
-      - master
+on: [push, pull_request]
 
 jobs:
 
@@ -11,6 +8,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
-      - uses: axel-op/googlejavaformat-action@v3
+      - uses: LGoodDatePicker/googlejavaformat-action@v3
         with:
           args: "--replace"
+          
+##### Notes #####
+
+### Used action repository:
+# The original action repository is here. (The master version.):
+#       - uses: axel-op/googlejavaformat-action@v3
+# However, we are using our own fork of this action. 
+# Our fork is located at:
+#       - uses: LGoodDatePicker/googlejavaformat-action@v3
+
+### Reason for using a fork:
+# The advantage of having our own fork of this action is that if the "axel-op" repository is
+# ever broken, then that break will not automaticatically break our own code. 
+# (Because we are not directly using the "axel-op" repository in our workflow.)
+
+### How to update our forked action repository:
+# Our fork of the action repository will only be updated when we manually click the update 
+# button in the LGoodDatePicker/googlejavaformat-action repository. 
+# The update button is named "Fetch Upstream". Clicking this button will update the fork to
+# the latest version of the action. 


### PR DESCRIPTION
In a previous pull request, @WiseEagleOwl said:

> I would like to propose the following changes to the code formatting Github action:
> Run it on every PR that is created, so that the code is already nicely formatted for the reviewer
> Do not run formatting on changes to the master branch. My reasoning for this is as follows:
> All changes coming through PRs are now already formatted so in that case running it again is unnecessary
> If there at any point in the future there is an issue with the formatting Github action (e.g. a corrupt formatter executable is downloaded) there would be broken commits that have been automatically committed to master
> Having formatting changes applied to PRs ensures these changed are also reviewed and possible issues with it will be detected early on

This change attempts to address these concerns, while still ensuring that all types of commits are formatted. As well as pull requests. 

What I did is fork the action to our own repository and use that fork in the workflow instead of the original action. 
- The fork will never automatically update. That means that a broken formatter action repository cannot break our own code. 
- The tradeoff is that we will need to manually click the "fetch updates" button in the fork repository to receive future updated versions of the action. 

Concerns are addressed as follows:
> Run it on every PR that is created, so that the code is already nicely formatted for the reviewer

This workflow runs on both pull requests, and pushes. So formatted code should also be present during review. 

> Do not run formatting on changes to the master branch. My reasoning for this is as follows:
> All changes coming through PRs are now already formatted so in that case running it again is unnecessary

In the case of a pull request, this workflow does run the formatter twice. however, the second run will not commit any changes to the files whenever the formatter does not detect that the file has changed. So although the second run is redundant for pull requests, it is harmless and will not create any "extra" commits. 

In the case where a pull request is not used, for example during a direct commit, the "push" based run will still format all code. In this way it is still useful to also format on push.

> If there at any point in the future there is an issue with the formatting Github action (e.g. a corrupt formatter executable 
> is downloaded) there would be broken commits that have been automatically committed to master
> Having formatting changes applied to PRs ensures these changed are also reviewed and possible issues with it will be 
> detected early on

This scenario is prevented by using a fork of the action, instead of using the original action directly. The tradeoff is that receiving any newer versions of the action will require a manual update of the fork. (Updates to the action are performed by clicking the "fetch updates" button on the forked repository.) Therefore the person who did the update to the action  will be aware that a break is possible, and can take a closer look at the formatted output of the next automatic format process. 

Let me know if this works for you. 
