### PR TITLE
Chore: replace concatenation with empty string

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -481,7 +481,7 @@ public class CalendarPanel extends JPanel {
       dateLabel.setForeground(Color.black);
       dateLabel.setBorder(null);
       dateLabel.setOpaque(true);
-      dateLabel.setText("" + i);
+      dateLabel.setText(String.valueOf(i));
       CellConstraints constraints = CC.xy(dateLabelColumnX, dateLabelRowY);
       centerPanel.add(dateLabel, constraints);
       dateLabels.add(dateLabel);
@@ -765,7 +765,7 @@ public class CalendarPanel extends JPanel {
     } else {
       labelMonth.setText(localizedFullMonth);
     }
-    final String displayedYearString = "" + displayedYear;
+    final String displayedYearString = String.valueOf(displayedYear);
     labelYear.setText(displayedYearString);
     if (!displayedYearString.equals(yearTextField.getText())) {
       // This invokeLater call fixes a bug where an exception was being thrown if you typed
@@ -891,7 +891,7 @@ public class CalendarPanel extends JPanel {
           selectedDateLabel = dateLabel;
         }
         // Set the text for the current date.
-        dateLabel.setText("" + dayOfMonth);
+        dateLabel.setText(String.valueOf(dayOfMonth));
         ++dayOfMonth;
       } else {
         // We are not inside the valid range, so set this label to an empty string.
@@ -920,7 +920,7 @@ public class CalendarPanel extends JPanel {
       if ((showWeekNumbers) && (weekNumberRules != null) && (weekNumberLabelIndex < usedRowCount)) {
         LocalDate firstDateInRow = firstDateInEachUsedRow.get(weekNumberLabelIndex);
         int weekNumber = zGetWeekNumberForASevenDayRange(firstDateInRow, weekNumberRules, false);
-        currentLabel.setText("" + weekNumber);
+        currentLabel.setText(String.valueOf(weekNumber));
       }
     }
 
@@ -1175,7 +1175,7 @@ public class CalendarPanel extends JPanel {
       // This try block handles exceptions that can occur at LocalDate.MAX.
       try {
         YearMonth choiceYearMonth = displayedYearMonth.plusYears(yearDifference);
-        String choiceYearMonthString = "" + choiceYearMonth.getYear();
+        String choiceYearMonthString = String.valueOf(choiceYearMonth.getYear());
         popupYear.add(
             new JMenuItem(
                 new AbstractAction(choiceYearMonthString) {

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
@@ -162,7 +162,7 @@ public class ExtraDateStrings {
     // Attempt to get the standalone version of the month name.
     TextStyle style = (shortVersion) ? TextStyle.SHORT_STANDALONE : TextStyle.FULL_STANDALONE;
     String monthName = month.getDisplayName(style, locale);
-    String monthNumber = "" + month.getValue();
+    String monthNumber = String.valueOf(month.getValue());
     // If no mapping was found, then get the "formatting version" of the month name.
     if (monthName.equals(monthNumber)) {
       DateFormatSymbols dateSymbols = DateFormatSymbols.getInstance(locale);

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
@@ -146,7 +146,7 @@ public class InternalUtilities {
       Properties properties = new Properties();
       ClassLoader classLoader = ClassLoader.getSystemClassLoader();
       properties.load(classLoader.getResourceAsStream("project.properties"));
-      return "" + properties.getProperty("targetJavaVersion");
+      return properties.getProperty("targetJavaVersion");
     } catch (Exception ex) {
       return "";
     }

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/JIntegerTextField.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/JIntegerTextField.java
@@ -72,7 +72,7 @@ public class JIntegerTextField extends JTextField {
 
   public JIntegerTextField(int preferredWidthFromColumnCount) {
     super(preferredWidthFromColumnCount);
-    setText("" + getDefaultValue());
+    setText(String.valueOf(getDefaultValue()));
     selectAll();
     AbstractDocument document = (AbstractDocument) this.getDocument();
     document.setDocumentFilter(new IntegerFilter(this));
@@ -150,7 +150,7 @@ public class JIntegerTextField extends JTextField {
   public void setValue(int value) {
     value = (value < minimumValue) ? minimumValue : value;
     value = (value > maximumValue) ? maximumValue : value;
-    setText("" + value);
+    setText(String.valueOf(value));
   }
 
   private boolean isValidInteger(String text) {
@@ -279,7 +279,7 @@ public class JIntegerTextField extends JTextField {
 
     private void setFieldToDefaultValue() {
       skipFiltersWhileTrue = true;
-      String defaultValue = "" + parentField.getDefaultValue();
+      String defaultValue = String.valueOf(parentField.getDefaultValue());
       parentField.setText(defaultValue);
       parentField.selectAll();
       skipFiltersWhileTrue = false;


### PR DESCRIPTION
Change string concatenations where one of the arguments is the empty string. Such a concatenation is unnecessary and inefficient, particularly when used as an idiom for formatting non-String objects or primitives into Strings.  Use `String.valueOf()` instead.