### PR TITLE
Chore: remove redundant array creation for varargs

### DIFF
--- a/Project/src/main/java/com/privatejgoodies/common/internal/RenderingUtils.java
+++ b/Project/src/main/java/com/privatejgoodies/common/internal/RenderingUtils.java
@@ -119,7 +119,7 @@ public final class RenderingUtils {
     if (drawStringUnderlineCharAtMethod != null) {
       try {
         drawStringUnderlineCharAtMethod.invoke(
-            null, new Object[] {c, g, text, underlinedIndex, x, y});
+            null, c, g, text, underlinedIndex, x, y);
         return;
       } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
         // Use the BasicGraphicsUtils as fallback
@@ -164,7 +164,7 @@ public final class RenderingUtils {
       Class<?> clazz = Class.forName(SWING_UTILITIES2_NAME);
       return clazz.getMethod(
           "drawString",
-          new Class[] {JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE});
+          JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE);
     } catch (ClassNotFoundException | SecurityException | NoSuchMethodException e) {
       // returns null
     }
@@ -176,9 +176,7 @@ public final class RenderingUtils {
       Class<?> clazz = Class.forName(SWING_UTILITIES2_NAME);
       return clazz.getMethod(
           "drawStringUnderlineCharAt",
-          new Class[] {
-            JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE, Integer.TYPE
-          });
+          JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE, Integer.TYPE);
     } catch (ClassNotFoundException | SecurityException | NoSuchMethodException e) {
       // returns null
     }
@@ -188,7 +186,7 @@ public final class RenderingUtils {
   private static Method getMethodGetFontMetrics() {
     try {
       Class<?> clazz = Class.forName(SWING_UTILITIES2_NAME);
-      return clazz.getMethod("getFontMetrics", new Class[] {JComponent.class, Graphics.class});
+      return clazz.getMethod("getFontMetrics", JComponent.class, Graphics.class);
     } catch (ClassNotFoundException | SecurityException | NoSuchMethodException e) {
       // returns null
     }

--- a/Project/src/main/java/com/privatejgoodies/common/internal/RenderingUtils.java
+++ b/Project/src/main/java/com/privatejgoodies/common/internal/RenderingUtils.java
@@ -118,8 +118,7 @@ public final class RenderingUtils {
       JComponent c, Graphics g, String text, int underlinedIndex, int x, int y) {
     if (drawStringUnderlineCharAtMethod != null) {
       try {
-        drawStringUnderlineCharAtMethod.invoke(
-            null, c, g, text, underlinedIndex, x, y);
+        drawStringUnderlineCharAtMethod.invoke(null, c, g, text, underlinedIndex, x, y);
         return;
       } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
         // Use the BasicGraphicsUtils as fallback
@@ -163,8 +162,7 @@ public final class RenderingUtils {
     try {
       Class<?> clazz = Class.forName(SWING_UTILITIES2_NAME);
       return clazz.getMethod(
-          "drawString",
-          JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE);
+          "drawString", JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE);
     } catch (ClassNotFoundException | SecurityException | NoSuchMethodException e) {
       // returns null
     }
@@ -176,7 +174,12 @@ public final class RenderingUtils {
       Class<?> clazz = Class.forName(SWING_UTILITIES2_NAME);
       return clazz.getMethod(
           "drawStringUnderlineCharAt",
-          JComponent.class, Graphics.class, String.class, Integer.TYPE, Integer.TYPE, Integer.TYPE);
+          JComponent.class,
+          Graphics.class,
+          String.class,
+          Integer.TYPE,
+          Integer.TYPE,
+          Integer.TYPE);
     } catch (ClassNotFoundException | SecurityException | NoSuchMethodException e) {
       // returns null
     }


### PR DESCRIPTION
Remove arrays that are created specifically to be passed as a varargs parameter.