### PR TITLE
Chore: remove redundant 'new' expression in constant array creation

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -407,16 +407,16 @@ public class CalendarPanel extends JPanel {
     // These two arrays represent the cell location of every border label.
     // Note that some coordinate combinations from these arrays are not used.
     // The array index is based on the border label index (not the cell location).
-    int[] labelLocations_X_forColumn = new int[] {0, 1, 2, 3, 4, 11};
-    int[] labelLocations_Y_forRow = new int[] {0, 1, 2, 5, 6, 12};
+    int[] labelLocations_X_forColumn = {0, 1, 2, 3, 4, 11};
+    int[] labelLocations_Y_forRow = {0, 1, 2, 5, 6, 12};
     // These integers represent the dimensions of every border label.
     // Note that some dimension combinations from these arrays are not used.
     // The array index is based on the border label index (not the cell location).
-    int[] labelWidthsInCells_forColumn = new int[] {0, 1, 1, 1, 7, 1};
-    int[] labelHeightsInCells_forRow = new int[] {0, 1, 3, 1, 6, 1};
+    int[] labelWidthsInCells_forColumn = {0, 1, 1, 1, 7, 1};
+    int[] labelHeightsInCells_forRow = {0, 1, 3, 1, 6, 1};
     // These points represent border label indexes that should be created and used.
     Point[] allBorderLabelIndexes =
-        new Point[] {
+        {
           new Point(1, 1),
           new Point(2, 1),
           new Point(3, 1),

--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -415,30 +415,29 @@ public class CalendarPanel extends JPanel {
     int[] labelWidthsInCells_forColumn = {0, 1, 1, 1, 7, 1};
     int[] labelHeightsInCells_forRow = {0, 1, 3, 1, 6, 1};
     // These points represent border label indexes that should be created and used.
-    Point[] allBorderLabelIndexes =
-        {
-          new Point(1, 1),
-          new Point(2, 1),
-          new Point(3, 1),
-          new Point(4, 1),
-          new Point(5, 1),
-          new Point(1, 2),
-          new Point(3, 2),
-          new Point(5, 2),
-          new Point(1, 3),
-          new Point(2, 3),
-          new Point(3, 3),
-          new Point(4, 3),
-          new Point(5, 3),
-          new Point(1, 4),
-          new Point(3, 4),
-          new Point(5, 4),
-          new Point(1, 5),
-          new Point(2, 5),
-          new Point(3, 5),
-          new Point(4, 5),
-          new Point(5, 5)
-        };
+    Point[] allBorderLabelIndexes = {
+      new Point(1, 1),
+      new Point(2, 1),
+      new Point(3, 1),
+      new Point(4, 1),
+      new Point(5, 1),
+      new Point(1, 2),
+      new Point(3, 2),
+      new Point(5, 2),
+      new Point(1, 3),
+      new Point(2, 3),
+      new Point(3, 3),
+      new Point(4, 3),
+      new Point(5, 3),
+      new Point(1, 4),
+      new Point(3, 4),
+      new Point(5, 4),
+      new Point(1, 5),
+      new Point(2, 5),
+      new Point(3, 5),
+      new Point(4, 5),
+      new Point(5, 5)
+    };
     // Create all the border labels.
     for (Point index : allBorderLabelIndexes) {
       Point labelLocationCell =

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -1782,7 +1782,7 @@ public class DatePickerSettings {
 
     // Create an array of all the FormatStyle enum values, from short to long.
     FormatStyle[] allFormatStyles =
-        new FormatStyle[] {
+        {
           FormatStyle.SHORT, FormatStyle.MEDIUM, FormatStyle.LONG, FormatStyle.FULL
         };
 

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -1781,10 +1781,9 @@ public class DatePickerSettings {
     setFormatForDatesBeforeCommonEra(formatForDatesBCE);
 
     // Create an array of all the FormatStyle enum values, from short to long.
-    FormatStyle[] allFormatStyles =
-        {
-          FormatStyle.SHORT, FormatStyle.MEDIUM, FormatStyle.LONG, FormatStyle.FULL
-        };
+    FormatStyle[] allFormatStyles = {
+      FormatStyle.SHORT, FormatStyle.MEDIUM, FormatStyle.LONG, FormatStyle.FULL
+    };
 
     // Create a set of default parsing formatters for the specified locale.
     ArrayList<DateTimeFormatter> parsingFormats = new ArrayList<>();

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -354,10 +354,9 @@ public class TimePickerSettings {
     formatForMenuTimes = ExtraTimeStrings.getDefaultFormatForMenuTimes(timeLocale);
 
     // Generate default parsing formats.
-    FormatStyle[] allFormatStyles =
-        {
-          FormatStyle.SHORT, FormatStyle.MEDIUM, FormatStyle.LONG, FormatStyle.FULL
-        };
+    FormatStyle[] allFormatStyles = {
+      FormatStyle.SHORT, FormatStyle.MEDIUM, FormatStyle.LONG, FormatStyle.FULL
+    };
     formatsForParsing = new ArrayList<>();
     formatsForParsing.add(DateTimeFormatter.ISO_LOCAL_TIME);
     for (FormatStyle formatStyle : allFormatStyles) {

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -355,7 +355,7 @@ public class TimePickerSettings {
 
     // Generate default parsing formats.
     FormatStyle[] allFormatStyles =
-        new FormatStyle[] {
+        {
           FormatStyle.SHORT, FormatStyle.MEDIUM, FormatStyle.LONG, FormatStyle.FULL
         };
     formatsForParsing = new ArrayList<>();

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
@@ -41,17 +41,9 @@ public class ExtraDateStrings {
    * extraParsingFormatsForLanguage_en, This is a constant list of extra parsing formats, which are
    * used for parsing dates in an English locale.
    */
-  private static final String[] extraParsingFormatsForLanguage_en =
-      {
-        "M/d/u",
-        "dMMMuu",
-        "dMMMuuuu",
-        "d MMM uu",
-        "d MMM uuuu",
-        "MMM d, u",
-        "MMM d u",
-        "MMM d, yyyy G"
-      };
+  private static final String[] extraParsingFormatsForLanguage_en = {
+    "M/d/u", "dMMMuu", "dMMMuuuu", "d MMM uu", "d MMM uuuu", "MMM d, u", "MMM d u", "MMM d, yyyy G"
+  };
 
   /**
    * extraParsingFormatsForLanguage_ru, This is a constant list of extra parsing formats, which are
@@ -66,21 +58,20 @@ public class ExtraDateStrings {
    * should only be used for visual reference. This can be used for comparison to ensure that the
    * general solution is functioning correctly.
    */
-  public static final String[] monthsNamesForLanguage_ru =
-      {
-        "январь",
-        "февраль",
-        "март",
-        "апрель",
-        "май",
-        "июнь",
-        "июль",
-        "август",
-        "сентябрь",
-        "октябрь",
-        "ноябрь",
-        "декабрь"
-      };
+  public static final String[] monthsNamesForLanguage_ru = {
+    "январь",
+    "февраль",
+    "март",
+    "апрель",
+    "май",
+    "июнь",
+    "июль",
+    "август",
+    "сентябрь",
+    "октябрь",
+    "ноябрь",
+    "декабрь"
+  };
 
   /**
    * getExtraParsingFormatsForLocale, This will return a list of extra parsing formatters for the

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraDateStrings.java
@@ -42,7 +42,7 @@ public class ExtraDateStrings {
    * used for parsing dates in an English locale.
    */
   private static final String[] extraParsingFormatsForLanguage_en =
-      new String[] {
+      {
         "M/d/u",
         "dMMMuu",
         "dMMMuuuu",
@@ -57,7 +57,7 @@ public class ExtraDateStrings {
    * extraParsingFormatsForLanguage_ru, This is a constant list of extra parsing formats, which are
    * used for parsing dates in a Russian locale.
    */
-  private static final String[] extraParsingFormatsForLanguage_ru = new String[] {"d MMM uuuu"};
+  private static final String[] extraParsingFormatsForLanguage_ru = {"d MMM uuuu"};
 
   /**
    * monthsNamesForLanguage_ru, This is a constant list of "standalone" month names, for the Russian
@@ -67,7 +67,7 @@ public class ExtraDateStrings {
    * general solution is functioning correctly.
    */
   public static final String[] monthsNamesForLanguage_ru =
-      new String[] {
+      {
         "январь",
         "февраль",
         "март",

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraTimeStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraTimeStrings.java
@@ -38,8 +38,7 @@ public class ExtraTimeStrings {
    * extraParsingFormatsForLanguage_en, This is a constant list of extra parsing formats, which are
    * used for parsing times in an English locale.
    */
-  private static final String[] extraParsingFormatsForLanguage_en =
-      {"h:ma", "h.ma", "ha"};
+  private static final String[] extraParsingFormatsForLanguage_en = {"h:ma", "h.ma", "ha"};
 
   /**
    * getExtraTimeParsingFormatsForLocale, This will return a list of extra parsing formatters for

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraTimeStrings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/ExtraTimeStrings.java
@@ -39,7 +39,7 @@ public class ExtraTimeStrings {
    * used for parsing times in an English locale.
    */
   private static final String[] extraParsingFormatsForLanguage_en =
-      new String[] {"h:ma", "h.ma", "ha"};
+      {"h:ma", "h.ma", "ha"};
 
   /**
    * getExtraTimeParsingFormatsForLocale, This will return a list of extra parsing formatters for

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeSpinnerTimer.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeSpinnerTimer.java
@@ -59,7 +59,7 @@ public class TimeSpinnerTimer {
    * millisForDivisorList, This indicates how long each value in the divisorList should be used,
    * before moving onto the next value in the divisorList.
    */
-  private final int[] millisForDivisorList = new int[] {1800, 900, 400, 400, 400, 400, 400, 0};
+  private final int[] millisForDivisorList = {1800, 900, 400, 400, 400, 400, 400, 0};
   /**
    * divisorList, For as long as any particular index in this array remains in effect, the currently
    * used number indicates how many tick calls should pass before the time picker value should be
@@ -67,7 +67,7 @@ public class TimeSpinnerTimer {
    * once for every 3 calls to the tick function. Higher numbers make the spinner change slower,
    * lower numbers make the spinner change faster.
    */
-  private final int[] divisorList = new int[] {12, 10, 8, 6, 4, 3, 2, 1};
+  private final int[] divisorList = {12, 10, 8, 6, 4, 3, 2, 1};
   /**
    * startedIndexTimeStamp, This indicates the time that the currently used index in the divisorList
    * started to be used.

--- a/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
@@ -83,7 +83,7 @@ public class TestParsingMatchFunction {
             .appendPattern("MMMM d, yyyy G")
             .toFormatter(Locale.getDefault());
     Month[] shortMonths =
-        new Month[] {Month.FEBRUARY, Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER};
+        {Month.FEBRUARY, Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER};
     // Make sure that none of short month dates match when given a nonexistent 31st date.
     for (int year = -10000; year < 10001; ++year) {
       for (Month shortMonth : shortMonths) {

--- a/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
+++ b/Project/src/test/java/com/github/lgooddatepicker/zinternaltools/TestParsingMatchFunction.java
@@ -82,8 +82,9 @@ public class TestParsingMatchFunction {
             .parseCaseInsensitive()
             .appendPattern("MMMM d, yyyy G")
             .toFormatter(Locale.getDefault());
-    Month[] shortMonths =
-        {Month.FEBRUARY, Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER};
+    Month[] shortMonths = {
+      Month.FEBRUARY, Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER
+    };
     // Make sure that none of short month dates match when given a nonexistent 31st date.
     for (int year = -10000; year < 10001; ++year) {
       for (Month shortMonth : shortMonths) {


### PR DESCRIPTION
Array initializers can omit the type because it is already specified in the left side of the assignment.