### PR TITLE
Chore: replace iteration with bulk operation

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePickerSettings.java
@@ -448,9 +448,7 @@ public class TimePickerSettings {
         timeSet.add(desiredTime);
       }
     }
-    for (LocalTime timeSetEntry : timeSet) {
-      potentialMenuTimes.add(timeSetEntry);
-    }
+    potentialMenuTimes.addAll(timeSet);
   }
 
   /**


### PR DESCRIPTION
Fix single operations inside loops that can be replaced with a bulk method.  Not only are bulk methods shorter, but in some cases they may be more performant as well.