### PR TITLE
Chore: use Java style instead of C style

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/CalendarPanel.java
@@ -706,7 +706,7 @@ public class CalendarPanel extends JPanel {
     // Get an instance of the calendar symbols for the current locale.
     DateFormatSymbols symbols = DateFormatSymbols.getInstance(settings.getLocale());
     // Get the days of the week in the local language.
-    String localShortDaysOfWeek[] = symbols.getShortWeekdays();
+    String[] localShortDaysOfWeek = symbols.getShortWeekdays();
     // Get the full month names in the current locale.
     int zeroBasedMonthIndex = (displayedMonth.getValue() - 1);
     String localizedFullMonth =


### PR DESCRIPTION
In C-style syntax the array indicator brackets are placed after the variable name or after the method parameter list whereas Java-style array declarations have array indicator brackets attached to the type name.