### PR TITLE
Only show legal years and provide up/down arrows for year selection popup

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -621,6 +621,9 @@ public class DatePickerSettings {
    * not exactly match the week number rules.
    */
   private boolean weekNumbersWillOverrideFirstDayOfWeek = true;
+  
+  /** yearSelectScroll, if to show up/down arrow on year select pop up */
+  private boolean yearSelectScroll = false;
 
   /**
    * zSkipDrawIndependentCalendarPanelIfNeeded, This is used to temporarily skip the named function,
@@ -800,7 +803,9 @@ public class DatePickerSettings {
     return borderPropertiesList;
   }
 
-  /** getCalendarPanelFactory, This returns the calendarPanelFactory or null. */
+  /**
+   * getCalendarPanelFactory, This returns the calendarPanelFactory or null.
+   */
   public Function<DatePicker, CalendarPanel> getCalendarPanelFactory() {
     return calendarPanelFactory;
   }
@@ -1182,6 +1187,11 @@ public class DatePickerSettings {
   public boolean getWeekNumbersWillOverrideFirstDayOfWeek() {
     return weekNumbersWillOverrideFirstDayOfWeek;
   }
+  
+  /** getYearSelectScroll, Returns the value of this setting (if to show up/down arrow on year select pop up) */
+  public boolean getYearSelectScroll() {
+    return yearSelectScroll;
+  }
 
   /**
    * hasParent, This returns true if this settings instance has a parent, otherwise returns false. A
@@ -1307,14 +1317,13 @@ public class DatePickerSettings {
   }
 
   /**
-   * setCalendarPanelFactory, This sets the factory used to construct instances of CalendarPanel. If
-   * it is null the standard CalendarPanel is instantiated.
-   *
+   * setCalendarPanelFactory, This sets the factory used to construct instances of CalendarPanel. If it is null
+   * the standard CalendarPanel is instantiated.
    * @param calendarPanelFactory
    */
   public void setCalendarPanelFactory(Function<DatePicker, CalendarPanel> calendarPanelFactory) {
     this.calendarPanelFactory = calendarPanelFactory;
-  }
+}
 
   /**
    * setClock, This sets the clock to use for determining the current date. By default the system
@@ -2169,6 +2178,11 @@ public class DatePickerSettings {
       boolean weekNumbersWillOverrideFirstDayOfWeek) {
     this.weekNumbersWillOverrideFirstDayOfWeek = weekNumbersWillOverrideFirstDayOfWeek;
     zDrawIndependentCalendarPanelIfNeeded();
+  }
+  
+  /** setYearSelectScroll, if to show up/down arrow on year select pop up */
+  public void setYearSelectScroll(boolean b) {
+    yearSelectScroll = b;
   }
 
   /**

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -711,6 +711,7 @@ public class DatePickerSettings {
         result.borderPropertiesList.add(borderProperty.clone());
       }
     }
+    result.calendarPanelFactory = this.calendarPanelFactory;
     result.colorBackgroundWeekNumberLabels = this.colorBackgroundWeekNumberLabels;
     result.colorBackgroundWeekdayLabels = this.colorBackgroundWeekdayLabels;
     if (this.colors == null) {
@@ -767,6 +768,7 @@ public class DatePickerSettings {
     result.weekNumberRules = this.weekNumberRules;
     result.weekNumbersDisplayed = this.weekNumbersDisplayed;
     result.weekNumbersWillOverrideFirstDayOfWeek = this.weekNumbersWillOverrideFirstDayOfWeek;
+    result.yearSelectScroll = this.yearSelectScroll;
     result.zSkipDrawIndependentCalendarPanelIfNeeded = false;
     return result;
   }


### PR DESCRIPTION
Year selection popup:
- Check if years are legal (if `DateVetoPolicyMinimumMaximumDate`), if not do not show the year
- New setting `yearSelectScroll` (off by default): put up and down arrow into year selection popup (see screenshots), to show popup again with other years.

Also: forgot `copySettings()` in my previous pull request

![year_full](https://user-images.githubusercontent.com/54671525/227013291-54825e3b-a2e1-4296-8b5a-edaf8f620986.png)

![year_up_only](https://user-images.githubusercontent.com/54671525/227013336-a9a0b5b1-9cf3-4b21-85a3-5e2ef701c628.png)

![year_down_only](https://user-images.githubusercontent.com/54671525/227013370-1fbaf6b2-6e8e-4ea7-8a16-733be1e28949.png)
