### PR TITLE
Chore: use try-with-resources to automatically close DataInputStream

### DIFF
--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePicker.java
@@ -158,6 +158,7 @@ public class DatePicker extends JPanel implements CustomPopupCloseListener {
   private JTextField dateTextField;
 
   private JButton toggleCalendarButton;
+
   // JFormDesigner - End of variables declaration  //GEN-END:variables
 
   /**

--- a/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/DatePickerSettings.java
@@ -285,6 +285,7 @@ public class DatePickerSettings {
    * by the JLabel component.
    */
   private Font fontCalendarWeekNumberLabels;
+
   /**
    * fontClearButton, This is the text font for the clear button. The default font is the normal
    * undecorated font, as provided by the JLabel component.
@@ -297,16 +298,19 @@ public class DatePickerSettings {
    * setColor() and "DateArea.DatePickerTextInvalidDate".)
    */
   private Font fontInvalidDate;
+
   /**
    * fontMonthAndYearMenuButtons, This is the text font for the month and year menu buttons. The
    * default font is the normal undecorated font, as provided by the JLabel component.
    */
   private Font fontMonthAndYearMenuLabels;
+
   /**
    * fontMonthAndYearNavigationButtons, This is the text font for the month and year navigation
    * buttons. The default font is the normal undecorated font, as provided by the JLabel component.
    */
   private Font fontMonthAndYearNavigationButtons;
+
   /**
    * fontTodayButton, This is the text font for the today button. The default font is the normal
    * undecorated font, as provided by the JLabel component.

--- a/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/components/TimePicker.java
@@ -164,6 +164,7 @@ public class TimePicker extends JPanel implements CustomPopup.CustomPopupCloseLi
   private JPanel spinnerPanel;
   private JButton increaseButton;
   private JButton decreaseButton;
+
   // JFormDesigner - End of variables declaration  //GEN-END:variables
 
   /**
@@ -755,6 +756,7 @@ public class TimePicker extends JPanel implements CustomPopup.CustomPopupCloseLi
            * the up arrow is released.
            */
           boolean upPressed = false;
+
           /**
            * downPressed, This indicates whether or not the down arrow has already been pressed.
            * This is used to make sure that we do not "react" to the down arrow multiple times when

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/DemoPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/DemoPanel.java
@@ -565,6 +565,7 @@ public class DemoPanel extends JPanel {
   public JPanel independentCalendarPanel;
   private JScrollPane messageTextAreaScrollPane;
   public JTextArea messageTextArea;
+
   // JFormDesigner - End of variables declaration  //GEN-END:variables
 
   public void addLabel(JPanel panel, int x, int pickerRow, String labelText) {

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/InternalUtilities.java
@@ -501,12 +501,13 @@ public class InternalUtilities {
    */
   public static int getCompiledJavaVersionFromJavaClassFile(
       InputStream classByteStream, boolean majorVersionRequested) throws Exception {
-    DataInputStream dataInputStream = new DataInputStream(classByteStream);
-    // Skip the "magic number".
-    dataInputStream.readInt();
-    int minorVersion = dataInputStream.readUnsignedShort();
-    int majorVersion = dataInputStream.readUnsignedShort();
-    return (majorVersionRequested) ? majorVersion : minorVersion;
+    try (DataInputStream dataInputStream = new DataInputStream(classByteStream)) {
+      // Skip the "magic number".
+      dataInputStream.readInt();
+      int minorVersion = dataInputStream.readUnsignedShort();
+      int majorVersion = dataInputStream.readUnsignedShort();
+      return (majorVersionRequested) ? majorVersion : minorVersion;
+    }
   }
 
   /**

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/MouseLiberalAdapter.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/MouseLiberalAdapter.java
@@ -79,6 +79,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
    * releasing the mouse.
    */
   private boolean isComponentPressedDown = false;
+
   /**
    * lastUnusedLiberalSingleClickTimeStamp, This stores a timestamp for the mouse release of the
    * last unused liberal single click. If a single click is "used" as part of a double click, then
@@ -86,6 +87,7 @@ public abstract class MouseLiberalAdapter extends MouseAdapter {
    * the above description, then this will contain the value zero.
    */
   private long lastUnusedLiberalSingleClickTimeStamp = 0;
+
   /**
    * slowestDoubleClickMilliseconds, This constant indicates the maximum time window in which a
    * liberal double click can occur. More specifically, this indicates the maximum time, in

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeMenuPanel.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeMenuPanel.java
@@ -257,6 +257,7 @@ public class TimeMenuPanel extends JPanel {
   // JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
   private JScrollPane timeScrollPane;
   private JList<String> timeList;
+
   // JFormDesigner - End of variables declaration  //GEN-END:variables
 
   private void tryClosePopup() {

--- a/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeSpinnerTimer.java
+++ b/Project/src/main/java/com/github/lgooddatepicker/zinternaltools/TimeSpinnerTimer.java
@@ -51,15 +51,18 @@ public class TimeSpinnerTimer {
    * value by only 1 minute.
    */
   private final int startDelayMillis = 700;
+
   /**
    * timerRate, This indicates how often the timer should call the tick function, in milliseconds.
    */
   private final int timerRate = 20;
+
   /**
    * millisForDivisorList, This indicates how long each value in the divisorList should be used,
    * before moving onto the next value in the divisorList.
    */
   private final int[] millisForDivisorList = {1800, 900, 400, 400, 400, 400, 400, 0};
+
   /**
    * divisorList, For as long as any particular index in this array remains in effect, the currently
    * used number indicates how many tick calls should pass before the time picker value should be
@@ -68,16 +71,19 @@ public class TimeSpinnerTimer {
    * lower numbers make the spinner change faster.
    */
   private final int[] divisorList = {12, 10, 8, 6, 4, 3, 2, 1};
+
   /**
    * startedIndexTimeStamp, This indicates the time that the currently used index in the divisorList
    * started to be used.
    */
   private long startedIndexTimeStamp = 0;
+
   /**
    * currentIndex, This indicates the index that is currently in effect for the divisorList and the
    * millisForIndexList.
    */
   private int currentIndex = 0;
+
   /**
    * ticksSinceIndexChange, This keeps track of the number of ticks that has passed since the last
    * time that the current index was changed. This helps us calculate when we need to change the

--- a/Project/src/main/java/com/privatejgoodies/forms/layout/Sizes.java
+++ b/Project/src/main/java/com/privatejgoodies/forms/layout/Sizes.java
@@ -66,6 +66,7 @@ public final class Sizes {
   public static final ConstantSize DLUX9 = dluX(9);
   public static final ConstantSize DLUX11 = dluX(11);
   public static final ConstantSize DLUX14 = dluX(14);
+
   /**
    * 21 horizontal dialog units.
    *
@@ -84,6 +85,7 @@ public final class Sizes {
   public static final ConstantSize DLUY9 = dluY(9);
   public static final ConstantSize DLUY11 = dluY(11);
   public static final ConstantSize DLUY14 = dluY(14);
+
   /**
    * 21 vertical dialog units.
    *


### PR DESCRIPTION
The `dataInputStream` was never closed resulting in a resource leak.

The blank line changes are the result of the formatting operation.