### PR TITLE
Chore: StringBuilder constructor call with 'char' argument

### DIFF
--- a/Project/src/main/java/com/privatejgoodies/forms/layout/FormSpecParser.java
+++ b/Project/src/main/java/com/privatejgoodies/forms/layout/FormSpecParser.java
@@ -230,7 +230,7 @@ public final class FormSpecParser {
   }
 
   private static String message(String source, int index, String description) {
-    StringBuffer buffer = new StringBuffer('\n');
+    StringBuffer buffer = new StringBuffer("\n");
     buffer.append('\n');
     buffer.append(source);
     buffer.append('\n');


### PR DESCRIPTION
The compiler silently casts the char argument to an integer and uses it as the initial capacity of the buffer.   Changed the argument to a string as this is the most likely expected behavior. 